### PR TITLE
feat: add Space timeline experience

### DIFF
--- a/src/components/layout/Layout.js
+++ b/src/components/layout/Layout.js
@@ -7,7 +7,8 @@ import AppShell from "./AppShell";
 function LayoutContent({ children }) {
   const { pathname } = useRouter();
 
-  const useShell = pathname !== "/about";
+  const isTimelinePage = /^\/space\/[^/]+\/timeline(?:\/)?$/.test(pathname);
+  const useShell = pathname !== "/about" && !isTimelinePage;
 
   if (!useShell) {
     return children;

--- a/src/components/space/timeline/SpaceTimeline.jsx
+++ b/src/components/space/timeline/SpaceTimeline.jsx
@@ -1,16 +1,9 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
-import { AnimatePresence, motion } from "framer-motion";
+import { motion } from "framer-motion";
 import { format } from "date-fns";
-import {
-  ArrowLeft,
-  ArrowRight,
-  CalendarDays,
-  ExternalLink,
-  MapPin,
-  Users,
-} from "lucide-react";
+import { ArrowLeft, ArrowRight, CalendarDays, ExternalLink, MapPin, Users } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -31,55 +24,18 @@ const FILTERS = [
 ];
 
 const EVENT_STYLES = {
-  space_created: {
-    accent: "border-primary/40 bg-primary/5",
-    dot: "bg-primary",
-  },
-  member_joined: {
-    accent: "border-violet-300/70 bg-violet-50/70 dark:border-violet-800 dark:bg-violet-950/20",
-    dot: "bg-violet-500",
-  },
-  report: {
-    accent: "border-blue-300/70 bg-blue-50/70 dark:border-blue-800 dark:bg-blue-950/20",
-    dot: "bg-blue-500",
-  },
-  meeting: {
-    accent: "border-amber-300/70 bg-amber-50/70 dark:border-amber-800 dark:bg-amber-950/20",
-    dot: "bg-amber-500",
-  },
-  event: {
-    accent: "border-emerald-300/70 bg-emerald-50/70 dark:border-emerald-800 dark:bg-emerald-950/20",
-    dot: "bg-emerald-500",
-  },
-  action: {
-    accent: "border-rose-300/70 bg-rose-50/70 dark:border-rose-800 dark:bg-rose-950/20",
-    dot: "bg-rose-500",
-  },
-  announcement: {
-    accent: "border-pink-300/70 bg-pink-50/70 dark:border-pink-800 dark:bg-pink-950/20",
-    dot: "bg-pink-500",
-  },
-  post: {
-    accent: "border-border bg-card",
-    dot: "bg-muted-foreground",
-  },
+  space_created: { accent: "border-primary/40 bg-primary/5", dot: "bg-primary" },
+  member_joined: { accent: "border-violet-300/70 bg-violet-50/70 dark:border-violet-800 dark:bg-violet-950/20", dot: "bg-violet-500" },
+  report: { accent: "border-blue-300/70 bg-blue-50/70 dark:border-blue-800 dark:bg-blue-950/20", dot: "bg-blue-500" },
+  meeting: { accent: "border-amber-300/70 bg-amber-50/70 dark:border-amber-800 dark:bg-amber-950/20", dot: "bg-amber-500" },
+  event: { accent: "border-emerald-300/70 bg-emerald-50/70 dark:border-emerald-800 dark:bg-emerald-950/20", dot: "bg-emerald-500" },
+  action: { accent: "border-rose-300/70 bg-rose-50/70 dark:border-rose-800 dark:bg-rose-950/20", dot: "bg-rose-500" },
+  announcement: { accent: "border-pink-300/70 bg-pink-50/70 dark:border-pink-800 dark:bg-pink-950/20", dot: "bg-pink-500" },
+  post: { accent: "border-border bg-card", dot: "bg-muted-foreground" },
 };
 
-function safeArray(value) {
-  return Array.isArray(value) ? value : [];
-}
-
-function getYear(date) {
-  return new Date(date).getFullYear();
-}
-
-function getFirstImage(event) {
-  const attachment = safeArray(event.attachments).find((item) =>
-    item?.mime_type?.startsWith("image/"),
-  );
-
-  return attachment?.public_url ?? null;
-}
+const safeArray = (value) => (Array.isArray(value) ? value : []);
+const getYear = (date) => new Date(date).getFullYear();
 
 function TimelineLinkPreview({ link }) {
   if (!link?.url) return null;
@@ -89,182 +45,92 @@ function TimelineLinkPreview({ link }) {
       href={link.url}
       target="_blank"
       rel="noreferrer"
-      onClick={(event) => event.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
       className="group/link mt-3 flex overflow-hidden rounded-2xl border bg-background/80 transition hover:border-foreground/20 hover:shadow-sm"
     >
       {link.image_url ? (
         <div className="h-20 w-24 shrink-0 overflow-hidden bg-muted">
-          <img
-            src={link.image_url}
-            alt=""
-            className="h-full w-full object-cover transition duration-300 group-hover/link:scale-105"
-          />
+          <img src={link.image_url} alt="" className="h-full w-full object-cover transition duration-300 group-hover/link:scale-105" />
         </div>
       ) : (
         <div className="flex h-20 w-20 shrink-0 items-center justify-center bg-muted">
-          {link.icon_url ? (
-            <img src={link.icon_url} alt="" className="h-7 w-7 object-contain" />
-          ) : (
-            <ExternalLink className="h-5 w-5 text-muted-foreground" />
-          )}
+          {link.icon_url ? <img src={link.icon_url} alt="" className="h-7 w-7 object-contain" /> : <ExternalLink className="h-5 w-5 text-muted-foreground" />}
         </div>
       )}
-
       <div className="min-w-0 flex-1 p-3">
-        <div className="line-clamp-1 text-sm font-medium">
-          {link.title || link.hostname || "External link"}
-        </div>
-        {link.description ? (
-          <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">
-            {link.description}
-          </div>
-        ) : null}
-        {link.hostname ? (
-          <div className="mt-1 text-[11px] text-muted-foreground">{link.hostname}</div>
-        ) : null}
+        <div className="line-clamp-1 text-sm font-medium">{link.title || link.hostname || "External link"}</div>
+        {link.description ? <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">{link.description}</div> : null}
+        {link.hostname ? <div className="mt-1 text-[11px] text-muted-foreground">{link.hostname}</div> : null}
       </div>
-
-      <div className="flex items-center px-3 text-muted-foreground">
-        <ExternalLink className="h-4 w-4" />
-      </div>
+      <div className="flex items-center px-3 text-muted-foreground"><ExternalLink className="h-4 w-4" /></div>
     </a>
   );
 }
 
-function TimelineEventCard({ event, index, onOpen }) {
+function TimelineEventCard({ event, index }) {
   const style = EVENT_STYLES[event.event_type] || EVENT_STYLES.post;
   const attachments = safeArray(event.attachments);
   const links = safeArray(event.links);
   const governance = safeArray(event.governance_entities);
-  const firstImage = getFirstImage(event);
-  const hasRichMedia = attachments.length > 0 || links.length > 0;
 
   return (
     <motion.div
       initial={{ opacity: 0, y: 18, scale: 0.98 }}
-      whileInView={{ opacity: 1, y: 0, scale: 1 }}
-      viewport={{ once: true, amount: 0.25 }}
-      transition={{ duration: 0.45, delay: Math.min(index * 0.03, 0.15) }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      transition={{ duration: 0.35, delay: Math.min(index * 0.025, 0.15) }}
       className="relative shrink-0 snap-center lg:w-[28rem]"
     >
       <div className="mb-3 flex items-center gap-3 px-1">
         <div className={`h-2.5 w-2.5 rounded-full ${style.dot} shadow-[0_0_0_5px_hsl(var(--background))]`} />
-        <div className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-          {event.label}
-        </div>
+        <div className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">{event.label}</div>
       </div>
 
-      <Card
-        onClick={() => onOpen?.(event)}
-        className={`group overflow-hidden rounded-[28px] border p-0 shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-lg ${style.accent} ${
-          event.post_id ? "cursor-pointer" : ""
-        }`}
-      >
-        {hasRichMedia ? (
+      <Card className={`group overflow-hidden rounded-[28px] border p-0 shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-lg ${style.accent}`}>
+        {attachments.length ? (
           <div className="relative h-52 overflow-hidden bg-muted">
-            {attachments.length ? (
-              <AutoImageCarousel attachments={attachments} />
-            ) : firstImage ? (
-              <img src={firstImage} alt="" className="h-full w-full object-cover" />
-            ) : null}
-
+            <AutoImageCarousel attachments={attachments} />
             <div className="absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/70 to-transparent" />
-
             <div className="absolute bottom-3 left-4 right-4 flex items-end justify-between gap-3 text-white">
               <div className="min-w-0">
-                <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/75">
-                  {format(new Date(event.occurred_at), "d MMMM yyyy")}
-                </div>
-                <div className="mt-1 line-clamp-2 text-lg font-semibold leading-tight">
-                  {event.title}
-                </div>
+                <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/75">{format(new Date(event.occurred_at), "d MMMM yyyy")}</div>
+                <div className="mt-1 line-clamp-2 text-lg font-semibold leading-tight">{event.title}</div>
               </div>
-
-              <Badge className="shrink-0 border-0 bg-black/45 text-[10px] text-white backdrop-blur">
-                {event.event_type === "member_joined" ? "PEOPLE" : event.event_type.toUpperCase()}
-              </Badge>
+              <Badge className="shrink-0 border-0 bg-black/45 text-[10px] text-white backdrop-blur">{event.event_type === "member_joined" ? "PEOPLE" : event.event_type.toUpperCase()}</Badge>
             </div>
           </div>
         ) : (
           <div className="px-5 pt-5">
             <div className="flex items-start justify-between gap-3">
               <div>
-                <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-                  {format(new Date(event.occurred_at), "d MMMM yyyy")}
-                </div>
-                <h3 className="mt-2 line-clamp-2 text-xl font-semibold tracking-tight">
-                  {event.title}
-                </h3>
+                <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">{format(new Date(event.occurred_at), "d MMMM yyyy")}</div>
+                <h3 className="mt-2 line-clamp-2 text-xl font-semibold tracking-tight">{event.title}</h3>
               </div>
-              <Badge variant="secondary" className="shrink-0">
-                {event.event_type === "member_joined" ? "People" : event.label}
-              </Badge>
+              <Badge variant="secondary" className="shrink-0">{event.event_type === "member_joined" ? "People" : event.label}</Badge>
             </div>
           </div>
         )}
 
         <div className="space-y-4 p-5">
-          {event.description ? (
-            <p className="line-clamp-4 text-sm leading-6 text-muted-foreground">
-              {event.description}
-            </p>
-          ) : null}
+          {event.description ? <p className="line-clamp-4 text-sm leading-6 text-muted-foreground">{event.description}</p> : null}
 
           {event.event_type === "member_joined" && event.actor_name ? (
             <div className="flex items-center gap-3">
-              <Avatar className="h-10 w-10">
-                <AvatarImage src={event.actor_avatar} alt="" />
-                <AvatarFallback>{event.actor_name.charAt(0)}</AvatarFallback>
-              </Avatar>
-              <div className="min-w-0">
-                <div className="font-medium">{event.actor_name}</div>
-                <div className="text-xs text-muted-foreground">
-                  {event.role || "Member"}
-                </div>
-              </div>
+              <Avatar className="h-10 w-10"><AvatarImage src={event.actor_avatar} alt="" /><AvatarFallback>{event.actor_name.charAt(0)}</AvatarFallback></Avatar>
+              <div className="min-w-0"><div className="font-medium">{event.actor_name}</div><div className="text-xs text-muted-foreground">{event.role || "Member"}</div></div>
             </div>
           ) : null}
 
-          {event.address ? (
-            <div className="flex items-start gap-2 text-xs text-muted-foreground">
-              <MapPin className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-              <span className="line-clamp-2">{event.address}</span>
-            </div>
-          ) : null}
+          {event.address ? <div className="flex items-start gap-2 text-xs text-muted-foreground"><MapPin className="mt-0.5 h-3.5 w-3.5 shrink-0" /><span className="line-clamp-2">{event.address}</span></div> : null}
 
-          {governance.length ? (
-            <div className="flex items-center justify-between gap-3 rounded-2xl border bg-background/60 px-3 py-2">
-              <span className="text-xs font-medium text-muted-foreground">Engaged with</span>
-              <GovernanceAvatarGroup authorities={governance} />
-            </div>
-          ) : null}
+          {governance.length ? <div className="flex items-center justify-between gap-3 rounded-2xl border bg-background/60 px-3 py-2"><span className="text-xs font-medium text-muted-foreground">Engaged with</span><GovernanceAvatarGroup authorities={governance} /></div> : null}
 
-          {links.slice(0, 2).map((link) => (
-            <TimelineLinkPreview key={link.id} link={link} />
-          ))}
+          {links.slice(0, 2).map((link) => <TimelineLinkPreview key={link.id} link={link} />)}
 
           <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
-            <div className="flex items-center gap-2">
-              {event.actor_name ? (
-                <>
-                  <Avatar className="h-6 w-6">
-                    <AvatarImage src={event.actor_avatar} alt="" />
-                    <AvatarFallback>{event.actor_name.charAt(0)}</AvatarFallback>
-                  </Avatar>
-                  <span className="max-w-32 truncate">{event.actor_name}</span>
-                </>
-              ) : null}
+            <div className="flex min-w-0 items-center gap-2">
+              {event.actor_name ? <><Avatar className="h-6 w-6"><AvatarImage src={event.actor_avatar} alt="" /><AvatarFallback>{event.actor_name.charAt(0)}</AvatarFallback></Avatar><span className="max-w-32 truncate">{event.actor_name}</span></> : null}
             </div>
-
-            {event.event_type === "space_created" ? (
-              <span className="inline-flex items-center gap-1">
-                <CalendarDays className="h-3.5 w-3.5" /> Founded
-              </span>
-            ) : event.event_type === "member_joined" ? (
-              <span className="inline-flex items-center gap-1">
-                <Users className="h-3.5 w-3.5" /> Joined
-              </span>
-            ) : null}
+            {event.event_type === "space_created" ? <span className="inline-flex items-center gap-1"><CalendarDays className="h-3.5 w-3.5" /> Founded</span> : event.event_type === "member_joined" ? <span className="inline-flex items-center gap-1"><Users className="h-3.5 w-3.5" /> Joined</span> : null}
           </div>
         </div>
       </Card>
@@ -272,132 +138,34 @@ function TimelineEventCard({ event, index, onOpen }) {
   );
 }
 
-export default function SpaceTimeline({ space, events = [], onOpen }) {
+export default function SpaceTimeline({ space, events = [] }) {
   const railRef = useRef(null);
   const [filter, setFilter] = useState("all");
-  const [activeYear, setActiveYear] = useState(() => {
-    const latest = events.at(-1);
-    return latest ? getYear(latest.occurred_at) : new Date().getFullYear();
-  });
+  const [activeYear, setActiveYear] = useState(() => events.at(-1) ? getYear(events.at(-1).occurred_at) : new Date().getFullYear());
+  const filteredEvents = useMemo(() => events.filter((event) => filter === "all" || event.event_type === filter), [events, filter]);
+  const years = useMemo(() => Array.from(new Set(events.map((event) => getYear(event.occurred_at)))).sort((a, b) => a - b), [events]);
+  const scrollBy = (amount) => railRef.current?.scrollBy({ left: amount, behavior: "smooth" });
+  const jumpToYear = (year) => { setActiveYear(year); railRef.current?.querySelector(`[data-year="${year}"]`)?.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" }); };
 
-  const filteredEvents = useMemo(() => {
-    return events.filter((event) => filter === "all" || event.event_type === filter);
-  }, [events, filter]);
-
-  const years = useMemo(() => {
-    return Array.from(new Set(events.map((event) => getYear(event.occurred_at)))).sort(
-      (a, b) => a - b,
-    );
-  }, [events]);
-
-  const scrollBy = (amount) => {
-    railRef.current?.scrollBy({ left: amount, behavior: "smooth" });
-  };
-
-  const jumpToYear = (year) => {
-    setActiveYear(year);
-    const target = railRef.current?.querySelector(`[data-year=\"${year}\"]`);
-    target?.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" });
-  };
-
-  if (!events.length) {
-    return (
-      <Card className="rounded-[28px] p-8 text-center">
-        <div className="mx-auto max-w-md">
-          <div className="text-lg font-semibold">No timeline yet</div>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Space history will appear here as people join and the team records reports,
-            meetings, events, actions and updates.
-          </p>
-        </div>
-      </Card>
-    );
-  }
+  if (!events.length) return <Card className="rounded-[28px] p-8 text-center"><div className="mx-auto max-w-md"><div className="text-lg font-semibold">No timeline yet</div><p className="mt-2 text-sm text-muted-foreground">Space history will appear here as people join and the team records reports, meetings, events, actions and updates.</p></div></Card>;
 
   return (
     <div className="space-y-5">
       <div className="flex flex-col gap-4 rounded-[28px] border bg-card/80 p-4 shadow-sm backdrop-blur md:p-5">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <div className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
-              History of {space?.name || "this Space"}
-            </div>
-            <h2 className="mt-1 text-2xl font-semibold tracking-tight sm:text-3xl">
-              Timeline
-            </h2>
-            <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">
-              A visual history of the people, work, meetings, events and actions that shaped this Space.
-            </p>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <Button variant="outline" size="icon" onClick={() => scrollBy(-520)} aria-label="Previous timeline events">
-              <ArrowLeft className="h-4 w-4" />
-            </Button>
-            <Button variant="outline" size="icon" onClick={() => scrollBy(520)} aria-label="Next timeline events">
-              <ArrowRight className="h-4 w-4" />
-            </Button>
-          </div>
+          <div><div className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">History of {space?.name || "this Space"}</div><h2 className="mt-1 text-2xl font-semibold tracking-tight sm:text-3xl">Timeline</h2><p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">A visual history of the people, work, meetings, events and actions that shaped this Space.</p></div>
+          <div className="flex items-center gap-2"><Button variant="outline" size="icon" onClick={() => scrollBy(-520)} aria-label="Previous timeline events"><ArrowLeft className="h-4 w-4" /></Button><Button variant="outline" size="icon" onClick={() => scrollBy(520)} aria-label="Next timeline events"><ArrowRight className="h-4 w-4" /></Button></div>
         </div>
-
-        <div className="flex items-center gap-2 overflow-x-auto pb-1">
-          {years.map((year) => (
-            <Button
-              key={year}
-              size="sm"
-              variant={activeYear === year ? "default" : "ghost"}
-              className="shrink-0 rounded-full"
-              onClick={() => jumpToYear(year)}
-            >
-              {year}
-            </Button>
-          ))}
-        </div>
-
-        <div className="flex items-center gap-2 overflow-x-auto pb-1">
-          {FILTERS.map(([value, label]) => (
-            <Button
-              key={value}
-              size="sm"
-              variant={filter === value ? "secondary" : "ghost"}
-              className="shrink-0 rounded-full"
-              onClick={() => setFilter(value)}
-            >
-              {label}
-            </Button>
-          ))}
-        </div>
+        <div className="flex items-center gap-2 overflow-x-auto pb-1">{years.map((year) => <Button key={year} size="sm" variant={activeYear === year ? "default" : "ghost"} className="shrink-0 rounded-full" onClick={() => jumpToYear(year)}>{year}</Button>)}</div>
+        <div className="flex items-center gap-2 overflow-x-auto pb-1">{FILTERS.map(([value, label]) => <Button key={value} size="sm" variant={filter === value ? "secondary" : "ghost"} className="shrink-0 rounded-full" onClick={() => setFilter(value)}>{label}</Button>)}</div>
       </div>
 
       <div className="relative overflow-hidden rounded-[32px] border bg-gradient-to-b from-muted/20 to-background">
         <div className="pointer-events-none absolute left-0 right-0 top-[118px] hidden h-px bg-border lg:block" />
-
-        <div
-          ref={railRef}
-          className="scrollbar-hide flex snap-x gap-6 overflow-x-auto px-4 pb-7 pt-10 sm:px-6 lg:px-10"
-        >
-          {filteredEvents.map((event, index) => {
-            const year = getYear(event.occurred_at);
-            return (
-              <div key={event.event_id} data-year={year} className="relative pt-5">
-                <TimelineEventCard event={event} index={index} onOpen={onOpen} />
-              </div>
-            );
-          })}
-        </div>
+        <div ref={railRef} className="scrollbar-hide flex snap-x gap-6 overflow-x-auto px-4 pb-7 pt-10 sm:px-6 lg:px-10">{filteredEvents.map((event, index) => <div key={event.event_id} data-year={getYear(event.occurred_at)} className="relative pt-5"><TimelineEventCard event={event} index={index} /></div>)}</div>
       </div>
 
-      <AnimatePresence mode="wait">
-        <motion.div
-          key={`${filter}-${filteredEvents.length}`}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          className="px-1 text-xs text-muted-foreground"
-        >
-          Showing {filteredEvents.length} timeline {filteredEvents.length === 1 ? "event" : "events"}
-        </motion.div>
-      </AnimatePresence>
+      <div className="px-1 text-xs text-muted-foreground">Showing {filteredEvents.length} timeline {filteredEvents.length === 1 ? "event" : "events"}</div>
     </div>
   );
 }

--- a/src/components/space/timeline/SpaceTimeline.jsx
+++ b/src/components/space/timeline/SpaceTimeline.jsx
@@ -1,0 +1,403 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { format } from "date-fns";
+import {
+  ArrowLeft,
+  ArrowRight,
+  CalendarDays,
+  ExternalLink,
+  MapPin,
+  Users,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import AutoImageCarousel from "@/components/attachment/AutoImageCarousel";
+import GovernanceAvatarGroup from "@/components/governance/GovernanceAvatarGroup";
+
+const FILTERS = [
+  ["all", "All"],
+  ["space_created", "Founded"],
+  ["member_joined", "People"],
+  ["report", "Reports"],
+  ["meeting", "Meetings"],
+  ["event", "Events"],
+  ["action", "Actions"],
+  ["announcement", "Updates"],
+];
+
+const EVENT_STYLES = {
+  space_created: {
+    accent: "border-primary/40 bg-primary/5",
+    dot: "bg-primary",
+  },
+  member_joined: {
+    accent: "border-violet-300/70 bg-violet-50/70 dark:border-violet-800 dark:bg-violet-950/20",
+    dot: "bg-violet-500",
+  },
+  report: {
+    accent: "border-blue-300/70 bg-blue-50/70 dark:border-blue-800 dark:bg-blue-950/20",
+    dot: "bg-blue-500",
+  },
+  meeting: {
+    accent: "border-amber-300/70 bg-amber-50/70 dark:border-amber-800 dark:bg-amber-950/20",
+    dot: "bg-amber-500",
+  },
+  event: {
+    accent: "border-emerald-300/70 bg-emerald-50/70 dark:border-emerald-800 dark:bg-emerald-950/20",
+    dot: "bg-emerald-500",
+  },
+  action: {
+    accent: "border-rose-300/70 bg-rose-50/70 dark:border-rose-800 dark:bg-rose-950/20",
+    dot: "bg-rose-500",
+  },
+  announcement: {
+    accent: "border-pink-300/70 bg-pink-50/70 dark:border-pink-800 dark:bg-pink-950/20",
+    dot: "bg-pink-500",
+  },
+  post: {
+    accent: "border-border bg-card",
+    dot: "bg-muted-foreground",
+  },
+};
+
+function safeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function getYear(date) {
+  return new Date(date).getFullYear();
+}
+
+function getFirstImage(event) {
+  const attachment = safeArray(event.attachments).find((item) =>
+    item?.mime_type?.startsWith("image/"),
+  );
+
+  return attachment?.public_url ?? null;
+}
+
+function TimelineLinkPreview({ link }) {
+  if (!link?.url) return null;
+
+  return (
+    <a
+      href={link.url}
+      target="_blank"
+      rel="noreferrer"
+      onClick={(event) => event.stopPropagation()}
+      className="group/link mt-3 flex overflow-hidden rounded-2xl border bg-background/80 transition hover:border-foreground/20 hover:shadow-sm"
+    >
+      {link.image_url ? (
+        <div className="h-20 w-24 shrink-0 overflow-hidden bg-muted">
+          <img
+            src={link.image_url}
+            alt=""
+            className="h-full w-full object-cover transition duration-300 group-hover/link:scale-105"
+          />
+        </div>
+      ) : (
+        <div className="flex h-20 w-20 shrink-0 items-center justify-center bg-muted">
+          {link.icon_url ? (
+            <img src={link.icon_url} alt="" className="h-7 w-7 object-contain" />
+          ) : (
+            <ExternalLink className="h-5 w-5 text-muted-foreground" />
+          )}
+        </div>
+      )}
+
+      <div className="min-w-0 flex-1 p-3">
+        <div className="line-clamp-1 text-sm font-medium">
+          {link.title || link.hostname || "External link"}
+        </div>
+        {link.description ? (
+          <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+            {link.description}
+          </div>
+        ) : null}
+        {link.hostname ? (
+          <div className="mt-1 text-[11px] text-muted-foreground">{link.hostname}</div>
+        ) : null}
+      </div>
+
+      <div className="flex items-center px-3 text-muted-foreground">
+        <ExternalLink className="h-4 w-4" />
+      </div>
+    </a>
+  );
+}
+
+function TimelineEventCard({ event, index, onOpen }) {
+  const style = EVENT_STYLES[event.event_type] || EVENT_STYLES.post;
+  const attachments = safeArray(event.attachments);
+  const links = safeArray(event.links);
+  const governance = safeArray(event.governance_entities);
+  const firstImage = getFirstImage(event);
+  const hasRichMedia = attachments.length > 0 || links.length > 0;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 18, scale: 0.98 }}
+      whileInView={{ opacity: 1, y: 0, scale: 1 }}
+      viewport={{ once: true, amount: 0.25 }}
+      transition={{ duration: 0.45, delay: Math.min(index * 0.03, 0.15) }}
+      className="relative shrink-0 snap-center lg:w-[28rem]"
+    >
+      <div className="mb-3 flex items-center gap-3 px-1">
+        <div className={`h-2.5 w-2.5 rounded-full ${style.dot} shadow-[0_0_0_5px_hsl(var(--background))]`} />
+        <div className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+          {event.label}
+        </div>
+      </div>
+
+      <Card
+        onClick={() => onOpen?.(event)}
+        className={`group overflow-hidden rounded-[28px] border p-0 shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-lg ${style.accent} ${
+          event.post_id ? "cursor-pointer" : ""
+        }`}
+      >
+        {hasRichMedia ? (
+          <div className="relative h-52 overflow-hidden bg-muted">
+            {attachments.length ? (
+              <AutoImageCarousel attachments={attachments} />
+            ) : firstImage ? (
+              <img src={firstImage} alt="" className="h-full w-full object-cover" />
+            ) : null}
+
+            <div className="absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/70 to-transparent" />
+
+            <div className="absolute bottom-3 left-4 right-4 flex items-end justify-between gap-3 text-white">
+              <div className="min-w-0">
+                <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/75">
+                  {format(new Date(event.occurred_at), "d MMMM yyyy")}
+                </div>
+                <div className="mt-1 line-clamp-2 text-lg font-semibold leading-tight">
+                  {event.title}
+                </div>
+              </div>
+
+              <Badge className="shrink-0 border-0 bg-black/45 text-[10px] text-white backdrop-blur">
+                {event.event_type === "member_joined" ? "PEOPLE" : event.event_type.toUpperCase()}
+              </Badge>
+            </div>
+          </div>
+        ) : (
+          <div className="px-5 pt-5">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                  {format(new Date(event.occurred_at), "d MMMM yyyy")}
+                </div>
+                <h3 className="mt-2 line-clamp-2 text-xl font-semibold tracking-tight">
+                  {event.title}
+                </h3>
+              </div>
+              <Badge variant="secondary" className="shrink-0">
+                {event.event_type === "member_joined" ? "People" : event.label}
+              </Badge>
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-4 p-5">
+          {event.description ? (
+            <p className="line-clamp-4 text-sm leading-6 text-muted-foreground">
+              {event.description}
+            </p>
+          ) : null}
+
+          {event.event_type === "member_joined" && event.actor_name ? (
+            <div className="flex items-center gap-3">
+              <Avatar className="h-10 w-10">
+                <AvatarImage src={event.actor_avatar} alt="" />
+                <AvatarFallback>{event.actor_name.charAt(0)}</AvatarFallback>
+              </Avatar>
+              <div className="min-w-0">
+                <div className="font-medium">{event.actor_name}</div>
+                <div className="text-xs text-muted-foreground">
+                  {event.role || "Member"}
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {event.address ? (
+            <div className="flex items-start gap-2 text-xs text-muted-foreground">
+              <MapPin className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span className="line-clamp-2">{event.address}</span>
+            </div>
+          ) : null}
+
+          {governance.length ? (
+            <div className="flex items-center justify-between gap-3 rounded-2xl border bg-background/60 px-3 py-2">
+              <span className="text-xs font-medium text-muted-foreground">Engaged with</span>
+              <GovernanceAvatarGroup authorities={governance} />
+            </div>
+          ) : null}
+
+          {links.slice(0, 2).map((link) => (
+            <TimelineLinkPreview key={link.id} link={link} />
+          ))}
+
+          <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+            <div className="flex items-center gap-2">
+              {event.actor_name ? (
+                <>
+                  <Avatar className="h-6 w-6">
+                    <AvatarImage src={event.actor_avatar} alt="" />
+                    <AvatarFallback>{event.actor_name.charAt(0)}</AvatarFallback>
+                  </Avatar>
+                  <span className="max-w-32 truncate">{event.actor_name}</span>
+                </>
+              ) : null}
+            </div>
+
+            {event.event_type === "space_created" ? (
+              <span className="inline-flex items-center gap-1">
+                <CalendarDays className="h-3.5 w-3.5" /> Founded
+              </span>
+            ) : event.event_type === "member_joined" ? (
+              <span className="inline-flex items-center gap-1">
+                <Users className="h-3.5 w-3.5" /> Joined
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </Card>
+    </motion.div>
+  );
+}
+
+export default function SpaceTimeline({ space, events = [], onOpen }) {
+  const railRef = useRef(null);
+  const [filter, setFilter] = useState("all");
+  const [activeYear, setActiveYear] = useState(() => {
+    const latest = events.at(-1);
+    return latest ? getYear(latest.occurred_at) : new Date().getFullYear();
+  });
+
+  const filteredEvents = useMemo(() => {
+    return events.filter((event) => filter === "all" || event.event_type === filter);
+  }, [events, filter]);
+
+  const years = useMemo(() => {
+    return Array.from(new Set(events.map((event) => getYear(event.occurred_at)))).sort(
+      (a, b) => a - b,
+    );
+  }, [events]);
+
+  const scrollBy = (amount) => {
+    railRef.current?.scrollBy({ left: amount, behavior: "smooth" });
+  };
+
+  const jumpToYear = (year) => {
+    setActiveYear(year);
+    const target = railRef.current?.querySelector(`[data-year=\"${year}\"]`);
+    target?.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" });
+  };
+
+  if (!events.length) {
+    return (
+      <Card className="rounded-[28px] p-8 text-center">
+        <div className="mx-auto max-w-md">
+          <div className="text-lg font-semibold">No timeline yet</div>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Space history will appear here as people join and the team records reports,
+            meetings, events, actions and updates.
+          </p>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-col gap-4 rounded-[28px] border bg-card/80 p-4 shadow-sm backdrop-blur md:p-5">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <div className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+              History of {space?.name || "this Space"}
+            </div>
+            <h2 className="mt-1 text-2xl font-semibold tracking-tight sm:text-3xl">
+              Timeline
+            </h2>
+            <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">
+              A visual history of the people, work, meetings, events and actions that shaped this Space.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="icon" onClick={() => scrollBy(-520)} aria-label="Previous timeline events">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+            <Button variant="outline" size="icon" onClick={() => scrollBy(520)} aria-label="Next timeline events">
+              <ArrowRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 overflow-x-auto pb-1">
+          {years.map((year) => (
+            <Button
+              key={year}
+              size="sm"
+              variant={activeYear === year ? "default" : "ghost"}
+              className="shrink-0 rounded-full"
+              onClick={() => jumpToYear(year)}
+            >
+              {year}
+            </Button>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-2 overflow-x-auto pb-1">
+          {FILTERS.map(([value, label]) => (
+            <Button
+              key={value}
+              size="sm"
+              variant={filter === value ? "secondary" : "ghost"}
+              className="shrink-0 rounded-full"
+              onClick={() => setFilter(value)}
+            >
+              {label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="relative overflow-hidden rounded-[32px] border bg-gradient-to-b from-muted/20 to-background">
+        <div className="pointer-events-none absolute left-0 right-0 top-[118px] hidden h-px bg-border lg:block" />
+
+        <div
+          ref={railRef}
+          className="scrollbar-hide flex snap-x gap-6 overflow-x-auto px-4 pb-7 pt-10 sm:px-6 lg:px-10"
+        >
+          {filteredEvents.map((event, index) => {
+            const year = getYear(event.occurred_at);
+            return (
+              <div key={event.event_id} data-year={year} className="relative pt-5">
+                <TimelineEventCard event={event} index={index} onOpen={onOpen} />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={`${filter}-${filteredEvents.length}`}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="px-1 text-xs text-muted-foreground"
+        >
+          Showing {filteredEvents.length} timeline {filteredEvents.length === 1 ? "event" : "events"}
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/hooks/space/useSpaceTimeline.js
+++ b/src/hooks/space/useSpaceTimeline.js
@@ -1,0 +1,24 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { supabase } from "@/lib/supabase/client";
+
+export function useSpaceTimeline(spaceId) {
+  return useQuery({
+    queryKey: ["space-timeline", spaceId],
+    enabled: !!spaceId,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("space_timeline_view")
+        .select("*")
+        .eq("space_id", spaceId)
+        .order("occurred_at", { ascending: true });
+
+      if (error) throw error;
+
+      return data ?? [];
+    },
+    staleTime: 1000 * 60 * 5,
+  });
+}

--- a/src/pages/space/[space].js
+++ b/src/pages/space/[space].js
@@ -2,12 +2,14 @@
 
 import { useState } from "react";
 import { useRouter } from "next/router";
+
 import { Settings, UserPlus, Plus } from "lucide-react";
 
 import EditorModal from "@/components/feed/editor/EditorModal";
 
 import { useAuth } from "@/context/AuthContext";
 import { useSpaces } from "@/hooks/space/useSpaces";
+import { useSpaceTimeline } from "@/hooks/space/useSpaceTimeline";
 
 import BackButton from "@/components/ui/back-button";
 import { Button } from "@/components/ui/button";
@@ -26,6 +28,7 @@ import MetaCardsSkeleton from "@/components/skeletons/MetaCardsSkeleton";
 import MembersTab from "@/components/space/tabs/MembersTab";
 import ActivityTab from "@/components/space/tabs/ActivityTab";
 import OverviewTab from "@/components/space/tabs/OverviewTab";
+import SpaceTimeline from "@/components/space/timeline/SpaceTimeline";
 
 export default function SpacePage() {
   const router = useRouter();
@@ -45,33 +48,28 @@ export default function SpacePage() {
     enabled: !!slug,
   });
 
+  const {
+    data: timeline = [],
+    isLoading: timelineLoading,
+  } = useSpaceTimeline(space?.id);
+
   const activeTab = tab || "overview";
 
   const base = `/space/${slug}`;
-
-  /* ========================================
-     LOADING
-  ======================================== */
 
   if (isLoading) {
     return (
       <div className="mx-auto max-w-6xl space-y-4 p-2">
         <PageHeaderSkeleton />
-
         <MetaCardsSkeleton />
       </div>
     );
   }
 
-  /* ========================================
-     ERROR
-  ======================================== */
-
   if (error || !space) {
     return (
       <div className="mx-auto max-w-6xl py-16 text-center">
         <h2 className="text-xl font-semibold">Space not found</h2>
-
         <p className="mt-2 text-muted-foreground">
           The requested space does not exist.
         </p>
@@ -79,26 +77,15 @@ export default function SpacePage() {
     );
   }
 
-  /* ========================================
-     SPACE PERMISSIONS
-  ======================================== */
-
   const isOwner = user?.id === space.owner_user_id;
-
   const isAdmin = space.current_user_role === "admin";
-
   const isMember = !!space.current_user_role;
-
   const canManage = isOwner || isAdmin;
 
   return (
     <>
       <div className="mx-auto max-w-6xl">
-        {/* ======================================
-            HEADER
-        ====================================== */}
-
-        <div className="sticky top-0 z-40 border-b bg-background backdrop-blur">
+        <div className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur">
           <div className="flex h-14 items-center gap-3 px-4 sm:h-16">
             <BackButton />
 
@@ -106,15 +93,7 @@ export default function SpacePage() {
               {space.name}
             </h1>
 
-            {/* ==================================
-                SPACE ACTIONS
-            ================================== */}
-
             <div className="flex shrink-0 items-center gap-1">
-              {/* ==================================
-                  CREATE POST
-              ================================== */}
-
               {user && (
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -128,16 +107,11 @@ export default function SpacePage() {
                       <Plus className="h-4 w-4" />
                     </Button>
                   </TooltipTrigger>
-
                   <TooltipContent>
                     <p>Create post</p>
                   </TooltipContent>
                 </Tooltip>
               )}
-
-              {/* ==================================
-                  SETTINGS
-              ================================== */}
 
               {canManage ? (
                 <Tooltip>
@@ -152,16 +126,11 @@ export default function SpacePage() {
                       <Settings className="h-4 w-4" />
                     </Button>
                   </TooltipTrigger>
-
                   <TooltipContent>
                     <p>Settings</p>
                   </TooltipContent>
                 </Tooltip>
               ) : !isMember ? (
-                /* ==================================
-                   BECOME A MEMBER
-                ================================== */
-
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
@@ -176,7 +145,6 @@ export default function SpacePage() {
                       <UserPlus className="h-4 w-4" />
                     </Button>
                   </TooltipTrigger>
-
                   <TooltipContent>
                     <p>Become a member</p>
                   </TooltipContent>
@@ -186,11 +154,7 @@ export default function SpacePage() {
           </div>
         </div>
 
-        {/* ======================================
-            TABS
-        ====================================== */}
-
-        <div className="sticky top-14 z-30 border-b bg-background p-2 sm:top-16">
+        <div className="sticky top-14 z-30 border-b bg-background/95 p-2 backdrop-blur sm:top-16">
           <Tabs value={activeTab}>
             <TabsList className="flex w-auto">
               <TabsTrigger
@@ -200,7 +164,13 @@ export default function SpacePage() {
               >
                 Overview
               </TabsTrigger>
-
+              <TabsTrigger
+                value="timeline"
+                onClick={() => router.push(`${base}?tab=timeline`)}
+                className="flex-1"
+              >
+                Timeline
+              </TabsTrigger>
               <TabsTrigger
                 value="members"
                 onClick={() => router.push(`${base}?tab=members`)}
@@ -208,7 +178,6 @@ export default function SpacePage() {
               >
                 Members
               </TabsTrigger>
-
               <TabsTrigger
                 value="activity"
                 onClick={() => router.push(`${base}?tab=activity`)}
@@ -220,31 +189,25 @@ export default function SpacePage() {
           </Tabs>
         </div>
 
-        {/* ======================================
-            CONTENT
-        ====================================== */}
-
         <div className="space-y-4 p-2 sm:p-4">
           <Tabs value={activeTab}>
-            {/* ==================================
-                OVERVIEW
-            ================================== */}
-
             <TabsContent value="overview">
               <OverviewTab space={space} />
             </TabsContent>
 
-            {/* ==================================
-                MEMBERS
-            ================================== */}
+            <TabsContent value="timeline">
+              {timelineLoading ? (
+                <div className="rounded-[28px] border bg-card p-8 text-sm text-muted-foreground">
+                  Loading Space history…
+                </div>
+              ) : (
+                <SpaceTimeline space={space} events={timeline} />
+              )}
+            </TabsContent>
 
             <TabsContent value="members">
               <MembersTab spaceId={space.id} spaceSlug={space.slug} />
             </TabsContent>
-
-            {/* ==================================
-                ACTIVITY
-            ================================== */}
 
             <TabsContent value="activity">
               <ActivityTab spaceId={space.id} />
@@ -252,10 +215,6 @@ export default function SpacePage() {
           </Tabs>
         </div>
       </div>
-
-      {/* ======================================
-          CREATE POST EDITOR
-      ====================================== */}
 
       <EditorModal
         isOpen={editorOpen}

--- a/src/pages/space/[space].js
+++ b/src/pages/space/[space].js
@@ -3,13 +3,12 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
 
-import { Settings, UserPlus, Plus } from "lucide-react";
+import { Settings, UserPlus, Plus, History } from "lucide-react";
 
 import EditorModal from "@/components/feed/editor/EditorModal";
 
 import { useAuth } from "@/context/AuthContext";
 import { useSpaces } from "@/hooks/space/useSpaces";
-import { useSpaceTimeline } from "@/hooks/space/useSpaceTimeline";
 
 import BackButton from "@/components/ui/back-button";
 import { Button } from "@/components/ui/button";
@@ -28,33 +27,20 @@ import MetaCardsSkeleton from "@/components/skeletons/MetaCardsSkeleton";
 import MembersTab from "@/components/space/tabs/MembersTab";
 import ActivityTab from "@/components/space/tabs/ActivityTab";
 import OverviewTab from "@/components/space/tabs/OverviewTab";
-import SpaceTimeline from "@/components/space/timeline/SpaceTimeline";
 
 export default function SpacePage() {
   const router = useRouter();
-
   const { user } = useAuth();
-
   const [editorOpen, setEditorOpen] = useState(false);
 
   const { space: slug, tab } = router.query;
 
-  const {
-    data: space,
-    isLoading,
-    error,
-  } = useSpaces({
+  const { data: space, isLoading, error } = useSpaces({
     slug,
     enabled: !!slug,
   });
 
-  const {
-    data: timeline = [],
-    isLoading: timelineLoading,
-  } = useSpaceTimeline(space?.id);
-
   const activeTab = tab || "overview";
-
   const base = `/space/${slug}`;
 
   if (isLoading) {
@@ -88,12 +74,28 @@ export default function SpacePage() {
         <div className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur">
           <div className="flex h-14 items-center gap-3 px-4 sm:h-16">
             <BackButton />
-
             <h1 className="min-w-0 flex-1 truncate font-semibold sm:text-lg">
               {space.name}
             </h1>
 
             <div className="flex shrink-0 items-center gap-1">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="shrink-0"
+                    aria-label="View Space timeline"
+                    onClick={() => router.push(`${base}/timeline`)}
+                  >
+                    <History className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>View timeline</p>
+                </TooltipContent>
+              </Tooltip>
+
               {user && (
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -165,13 +167,6 @@ export default function SpacePage() {
                 Overview
               </TabsTrigger>
               <TabsTrigger
-                value="timeline"
-                onClick={() => router.push(`${base}?tab=timeline`)}
-                className="flex-1"
-              >
-                Timeline
-              </TabsTrigger>
-              <TabsTrigger
                 value="members"
                 onClick={() => router.push(`${base}?tab=members`)}
                 className="flex-1"
@@ -194,21 +189,9 @@ export default function SpacePage() {
             <TabsContent value="overview">
               <OverviewTab space={space} />
             </TabsContent>
-
-            <TabsContent value="timeline">
-              {timelineLoading ? (
-                <div className="rounded-[28px] border bg-card p-8 text-sm text-muted-foreground">
-                  Loading Space history…
-                </div>
-              ) : (
-                <SpaceTimeline space={space} events={timeline} />
-              )}
-            </TabsContent>
-
             <TabsContent value="members">
               <MembersTab spaceId={space.id} spaceSlug={space.slug} />
             </TabsContent>
-
             <TabsContent value="activity">
               <ActivityTab spaceId={space.id} />
             </TabsContent>

--- a/src/pages/space/[space]/timeline.js
+++ b/src/pages/space/[space]/timeline.js
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/router";
 import { motion } from "framer-motion";
 import { ArrowLeft, ArrowRight, ArrowUpRight, History } from "lucide-react";
 import { format } from "date-fns";
@@ -22,14 +23,62 @@ import PageHeaderSkeleton from "@/components/skeletons/PageHeaderSkeleton";
 import AutoImageCarousel from "@/components/attachment/AutoImageCarousel";
 
 const NATURAL_TEXT = {
-  space_created: ["This is where the story began", "This is where the work started", "The first page of the story", "The beginning of something local", "This is where it all came together"],
-  member_joined: ["Someone new joined the team", "Another person came on board", "The team grew a little stronger", "A new contributor joined in", "Another pair of hands joined the effort"],
-  report: ["A piece of work took shape", "The team moved an idea forward", "Something useful came together", "The team put its findings on record", "The work turned into something concrete"],
-  meeting: ["The team sat down to work through it", "People came together to figure it out", "A conversation moved the work forward", "The right people got around the table", "The team made time to work through the details"],
-  event: ["The team showed up", "The team stepped into the wider conversation", "The work met the real world", "The team took part in the moment", "The team was there for it"],
-  action: ["Something was done", "The team moved from words to action", "A small step became a real action", "The team followed through", "The work moved into the real world"],
-  announcement: ["Something important was shared", "The team had an update to share", "A new chapter was announced", "The team shared where things stood", "A useful update made its way out"],
-  post: ["A moment worth keeping", "Something the team wanted on record", "Another piece of the story", "A moment from along the way", "One more chapter in the journey"],
+  space_created: [
+    "This is where the story began",
+    "This is where the work started",
+    "The first page of the story",
+    "The beginning of something local",
+    "This is where it all came together",
+  ],
+  member_joined: [
+    "Someone new joined the team",
+    "Another person came on board",
+    "The team grew a little stronger",
+    "A new contributor joined in",
+    "Another pair of hands joined the effort",
+  ],
+  report: [
+    "A piece of work took shape",
+    "The team moved an idea forward",
+    "Something useful came together",
+    "The team put its findings on record",
+    "The work turned into something concrete",
+  ],
+  meeting: [
+    "The team sat down to work through it",
+    "People came together to figure it out",
+    "A conversation moved the work forward",
+    "The right people got around the table",
+    "The team made time to work through the details",
+  ],
+  event: [
+    "The team showed up",
+    "The team stepped into the wider conversation",
+    "The work met the real world",
+    "The team took part in the moment",
+    "The team was there for it",
+  ],
+  action: [
+    "Something was done",
+    "The team moved from words to action",
+    "A small step became a real action",
+    "The team followed through",
+    "The work moved into the real world",
+  ],
+  announcement: [
+    "Something important was shared",
+    "The team had an update to share",
+    "A new chapter was announced",
+    "The team shared where things stood",
+    "A useful update made its way out",
+  ],
+  post: [
+    "A moment worth keeping",
+    "Something the team wanted on record",
+    "Another piece of the story",
+    "A moment from along the way",
+    "One more chapter in the journey",
+  ],
 };
 
 const GOVERNANCE_TEXT = {
@@ -40,46 +89,67 @@ const GOVERNANCE_TEXT = {
   person: ["with", "alongside", "in conversation with"],
 };
 
-const TIMELINE_PALETTE = [
-  { base: "#2563eb", soft: "#dbeafe" },
-  { base: "#16a34a", soft: "#dcfce7" },
-  { base: "#d97706", soft: "#fef3c7" },
-  { base: "#7c3aed", soft: "#ede9fe" },
-  { base: "#db2777", soft: "#fce7f3" },
+const TIMELINE_COLORS = [
+  { line: "#2563eb", soft: "rgba(37,99,235,0.16)", dark: "#1d4ed8" },
+  { line: "#059669", soft: "rgba(5,150,105,0.16)", dark: "#047857" },
+  { line: "#d97706", soft: "rgba(217,119,6,0.16)", dark: "#b45309" },
+  { line: "#7c3aed", soft: "rgba(124,58,237,0.16)", dark: "#6d28d9" },
+  { line: "#db2777", soft: "rgba(219,39,119,0.16)", dark: "#be185d" },
 ];
 
-function safeArray(value) { return Array.isArray(value) ? value : []; }
+function safeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
 
 function pickVariant(event, items) {
   const key = String(event.event_id || event.post_id || event.title || "timeline");
   let hash = 0;
-  for (let index = 0; index < key.length; index += 1) hash = (hash * 31 + key.charCodeAt(index)) >>> 0;
+
+  for (let index = 0; index < key.length; index += 1) {
+    hash = (hash * 31 + key.charCodeAt(index)) >>> 0;
+  }
+
   return items[hash % items.length];
 }
 
-function paletteFor(index) { return TIMELINE_PALETTE[index % TIMELINE_PALETTE.length]; }
-
 function naturalLabel(event) {
-  return `${pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}: ${event.title || "this moment"}.`;
+  const title = event.title || "this moment";
+  return `${pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}: ${title}.`;
 }
 
 function governanceSentence(event, teamName) {
   const governance = safeArray(event.governance_entities);
   if (!governance.length) return null;
+
   const item = governance[0];
   const name = item.short_name || item.label || "an authority";
   const type = item.entity_type || "authority";
   const phrase = pickVariant(event, GOVERNANCE_TEXT[type] || GOVERNANCE_TEXT.authority);
   const relationship = String(item.relationship_type || "").toLowerCase();
   const actor = teamName || "The team";
-  if (relationship.includes("respons") || relationship.includes("owner") || relationship.includes("jurisdiction")) return `${actor} worked under ${name}.`;
-  if (relationship.includes("collabor") || relationship.includes("partner")) return `${actor} worked alongside ${name}.`;
-  if (relationship.includes("engag")) return `${actor} was in conversation with ${name}.`;
+
+  if (
+    relationship.includes("respons") ||
+    relationship.includes("owner") ||
+    relationship.includes("jurisdiction")
+  ) {
+    return `${actor} worked under ${name}.`;
+  }
+
+  if (relationship.includes("collabor") || relationship.includes("partner")) {
+    return `${actor} worked alongside ${name}.`;
+  }
+
+  if (relationship.includes("engag")) {
+    return `${actor} was in conversation with ${name}.`;
+  }
+
   return `${actor} worked ${phrase} ${name}.`;
 }
 
 function MemberIdentity({ event, light = false }) {
   if (event.event_type !== "member_joined") return null;
+
   return (
     <div className={`flex items-center gap-2 ${light ? "text-white/85" : "text-foreground"}`}>
       <Avatar className={`h-9 w-9 border ${light ? "border-white/20" : "border-border"}`}>
@@ -97,11 +167,16 @@ function MemberIdentity({ event, light = false }) {
 function GovernanceRow({ event, light = false }) {
   const governance = safeArray(event.governance_entities);
   if (!governance.length) return null;
+
   return (
     <div className={`flex flex-wrap items-center gap-2 ${light ? "text-white/80" : "text-muted-foreground"}`}>
       {governance.slice(0, 4).map((item) => (
         <div key={item.id} className={`flex items-center gap-2 rounded-full border px-2.5 py-1.5 backdrop-blur ${light ? "border-white/15 bg-white/5" : "border-border bg-background/70"}`}>
-          {item.image_url ? <img src={item.image_url} alt="" className="h-5 w-5 rounded-full object-contain" /> : <div className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[9px] font-semibold">{(item.short_name || item.label || "G").charAt(0)}</div>}
+          {item.image_url ? (
+            <img src={item.image_url} alt="" className="h-5 w-5 rounded-full object-contain" />
+          ) : (
+            <div className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[9px] font-semibold">{(item.short_name || item.label || "G").charAt(0)}</div>
+          )}
           <span className="max-w-32 truncate text-[11px] font-medium">{item.short_name || item.label}</span>
         </div>
       ))}
@@ -111,16 +186,27 @@ function GovernanceRow({ event, light = false }) {
 
 function LinkList({ links = [] }) {
   if (!links.length) return null;
+
   return (
-    <div className="flex flex-col gap-3">
+    <div className="space-y-3">
       {links.slice(0, 4).map((link) => (
-        <a key={link.id} href={link.url} target="_blank" rel="noreferrer" className="group flex items-center gap-3 rounded-2xl border bg-background p-3 transition hover:bg-muted/60">
-          {link.image_url ? <img src={link.image_url} alt="" className="h-16 w-24 shrink-0 rounded-xl object-cover" /> : <div className="flex h-16 w-24 shrink-0 items-center justify-center rounded-xl bg-muted text-xs text-muted-foreground">Link</div>}
-          <div className="min-w-0 flex-1">
-            <div className="line-clamp-2 text-sm font-medium leading-5">{link.title || link.hostname || link.url}</div>
-            <div className="mt-1 truncate text-xs text-muted-foreground">{link.url}</div>
+        <a
+          key={link.id}
+          href={link.url}
+          target="_blank"
+          rel="noreferrer"
+          className="group block overflow-hidden rounded-2xl border bg-background transition hover:bg-muted/40"
+        >
+          {link.image_url ? (
+            <img src={link.image_url} alt="" className="h-40 w-full object-cover" />
+          ) : null}
+          <div className="flex items-center justify-between gap-4 px-4 py-3">
+            <div className="min-w-0">
+              <div className="truncate text-xs font-medium text-muted-foreground">{link.title || link.hostname || link.url}</div>
+              <div className="mt-1 truncate text-xs text-muted-foreground/80">{link.url}</div>
+            </div>
+            <ArrowUpRight className="h-4 w-4 shrink-0 transition group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
           </div>
-          <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground transition group-hover:text-foreground" />
         </a>
       ))}
     </div>
@@ -131,6 +217,7 @@ function EventDialog({ event, teamName, open, onOpenChange }) {
   const imageAttachments = safeArray(event.attachments).filter((item) => item?.mime_type?.startsWith("image/"));
   const links = safeArray(event.links);
   const governanceCopy = governanceSentence(event, teamName);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[88vh] max-w-4xl overflow-y-auto rounded-[30px] border bg-background p-0">
@@ -145,10 +232,26 @@ function EventDialog({ event, teamName, open, onOpenChange }) {
               </div>
             </div>
           ) : null}
+
           <div className="space-y-5 p-6 sm:p-8">
-            {!imageAttachments.length ? <div><div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{format(new Date(event.occurred_at), "d MMMM yyyy")}</div><DialogTitle className="mt-2 text-3xl font-semibold tracking-tight sm:text-4xl">{event.title}</DialogTitle></div> : null}
+            {!imageAttachments.length ? (
+              <div>
+                <div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{format(new Date(event.occurred_at), "d MMMM yyyy")}</div>
+                <DialogTitle className="mt-2 text-3xl font-semibold tracking-tight sm:text-4xl">{event.title}</DialogTitle>
+              </div>
+            ) : null}
+
             <DialogDescription className="text-base leading-7 text-muted-foreground">{event.description || naturalLabel(event)}</DialogDescription>
-            {event.event_type === "member_joined" ? <MemberIdentity event={event} /> : event.actor_name ? <div className="flex items-center gap-2 text-sm text-muted-foreground"><Avatar className="h-8 w-8 border"><AvatarImage src={event.actor_avatar} alt={event.actor_name} /><AvatarFallback>{event.actor_name.charAt(0).toUpperCase()}</AvatarFallback></Avatar><span>{event.actor_name}</span></div> : null}
+
+            {event.event_type === "member_joined" ? (
+              <MemberIdentity event={event} />
+            ) : event.actor_name ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Avatar className="h-8 w-8 border"><AvatarImage src={event.actor_avatar} alt={event.actor_name} /><AvatarFallback>{event.actor_name.charAt(0).toUpperCase()}</AvatarFallback></Avatar>
+                <span>{event.actor_name}</span>
+              </div>
+            ) : null}
+
             {governanceCopy ? <p className="text-sm leading-6 text-muted-foreground">{governanceCopy}</p> : null}
             <GovernanceRow event={event} />
             {event.address ? <div className="rounded-2xl border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">{event.address}</div> : null}
@@ -164,14 +267,24 @@ export default function SpaceTimelinePage() {
   const router = useRouter();
   const railRef = useRef(null);
   const { space: slug } = router.query;
+
   const { data: space, isLoading, error } = useSpaces({ slug, enabled: !!slug });
   const { data: timeline = [], isLoading: timelineLoading } = useSpaceTimeline(space?.id);
+
   const [filter, setFilter] = useState("all");
   const [selectedEvent, setSelectedEvent] = useState(null);
-  const [focusIndex, setFocusIndex] = useState(0);
+  const [activeMonth, setActiveMonth] = useState(null);
 
-  const filteredEvents = useMemo(() => timeline.filter((event) => filter === "all" || event.event_type === filter), [timeline, filter]);
-  const years = useMemo(() => Array.from(new Set(filteredEvents.map((event) => new Date(event.occurred_at).getFullYear()))).sort((a, b) => a - b), [filteredEvents]);
+  const filteredEvents = useMemo(
+    () => timeline.filter((event) => filter === "all" || event.event_type === filter),
+    [timeline, filter],
+  );
+
+  const years = useMemo(
+    () => Array.from(new Set(filteredEvents.map((event) => new Date(event.occurred_at).getFullYear()))).sort((a, b) => a - b),
+    [filteredEvents],
+  );
+
   const monthMarkers = useMemo(() => {
     const seen = new Set();
     return filteredEvents.reduce((markers, event, index) => {
@@ -179,38 +292,23 @@ export default function SpaceTimelinePage() {
       const key = format(date, "yyyy-MM");
       if (seen.has(key)) return markers;
       seen.add(key);
-      markers.push({ key, label: format(date, "MMM yyyy"), year: date.getFullYear(), index });
+      markers.push({
+        key,
+        label: format(date, "MMM yyyy"),
+        year: date.getFullYear(),
+        index,
+      });
       return markers;
     }, []);
   }, [filteredEvents]);
+
   const teamName = space?.name ? `${space.name} team` : "The team";
+  const activeMonthIndex = activeMonth ? monthMarkers.findIndex((month) => month.key === activeMonth) : -1;
 
   useEffect(() => {
     const rail = railRef.current;
     if (!rail) return undefined;
-    const handleScroll = () => {
-      const cards = Array.from(rail.querySelectorAll("[data-event-index]"));
-      if (!cards.length) return;
-      const center = rail.scrollLeft + rail.clientWidth / 2;
-      let nearest = 0;
-      let distance = Number.POSITIVE_INFINITY;
-      cards.forEach((card, index) => {
-        const rect = card.getBoundingClientRect();
-        const railRect = rail.getBoundingClientRect();
-        const cardCenter = rect.left - railRect.left + rail.scrollLeft + rect.width / 2;
-        const nextDistance = Math.abs(cardCenter - center);
-        if (nextDistance < distance) { distance = nextDistance; nearest = Number(card.dataset.eventIndex ?? index); }
-      });
-      setFocusIndex(nearest);
-    };
-    handleScroll();
-    rail.addEventListener("scroll", handleScroll, { passive: true });
-    return () => rail.removeEventListener("scroll", handleScroll);
-  }, [filteredEvents.length]);
 
-  useEffect(() => {
-    const rail = railRef.current;
-    if (!rail) return undefined;
     const handleWheel = (event) => {
       if (Math.abs(event.deltaY) <= Math.abs(event.deltaX) || Math.abs(event.deltaY) < 2) return;
       const atStart = rail.scrollLeft <= 0 && event.deltaY < 0;
@@ -219,18 +317,59 @@ export default function SpaceTimelinePage() {
       event.preventDefault();
       rail.scrollLeft += event.deltaY;
     };
+
+    const handleScroll = () => {
+      const children = rail.querySelectorAll("[data-month]");
+      let closest = null;
+      let distance = Infinity;
+      const center = rail.scrollLeft + rail.clientWidth / 2;
+      children.forEach((child) => {
+        const childCenter = child.offsetLeft + child.offsetWidth / 2;
+        const diff = Math.abs(childCenter - center);
+        if (diff < distance) {
+          distance = diff;
+          closest = child.dataset.month;
+        }
+      });
+      if (closest) setActiveMonth(closest);
+    };
+
     rail.addEventListener("wheel", handleWheel, { passive: false });
-    return () => rail.removeEventListener("wheel", handleWheel);
-  }, []);
+    rail.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll();
 
-  const jump = (direction) => railRef.current?.scrollBy({ left: direction * Math.max(window.innerWidth * 0.72, 460), behavior: "smooth" });
-  const jumpToYear = (year) => railRef.current?.querySelector(`[data-year="${year}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
-  const jumpToMonth = (monthKey) => railRef.current?.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+    return () => {
+      rail.removeEventListener("wheel", handleWheel);
+      rail.removeEventListener("scroll", handleScroll);
+    };
+  }, [filteredEvents.length]);
 
-  if (isLoading || timelineLoading) return <div className="min-h-dvh bg-background"><PageHeaderSkeleton /></div>;
-  if (error || !space) return <div className="flex min-h-dvh items-center justify-center bg-background px-6 text-center"><div><h1 className="text-2xl font-semibold">Space not found</h1><p className="mt-2 text-muted-foreground">The requested Space does not exist.</p></div></div>;
+  const jump = (direction) => {
+    railRef.current?.scrollBy({ left: direction * Math.max(window.innerWidth * 0.72, 460), behavior: "smooth" });
+  };
 
-  const focusedPalette = paletteFor(focusIndex);
+  const jumpToYear = (year) => {
+    railRef.current?.querySelector(`[data-year="${year}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+  };
+
+  const jumpToMonth = (monthKey) => {
+    railRef.current?.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+  };
+
+  if (isLoading || timelineLoading) {
+    return <div className="min-h-dvh bg-background"><PageHeaderSkeleton /></div>;
+  }
+
+  if (error || !space) {
+    return (
+      <div className="flex min-h-dvh items-center justify-center bg-background px-6 text-center">
+        <div>
+          <h1 className="text-2xl font-semibold">Space not found</h1>
+          <p className="mt-2 text-muted-foreground">The requested Space does not exist.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="relative min-h-dvh overflow-hidden bg-background">
@@ -243,7 +382,10 @@ export default function SpaceTimelinePage() {
       <div className="relative z-10 flex min-h-dvh flex-col">
         <header className="flex items-center gap-3 border-b border-border/70 px-4 py-3 sm:px-6 lg:px-8">
           <BackButton />
-          <div className="min-w-0 flex-1"><div className="truncate text-sm font-medium">{space.name}</div><div className="text-xs text-muted-foreground">The story so far</div></div>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium">{space.name}</div>
+            <div className="text-xs text-muted-foreground">The story so far</div>
+          </div>
           <Button variant="ghost" asChild className="rounded-full"><Link href={`/space/${space.slug}`}>Back to {space.name}</Link></Button>
         </header>
 
@@ -259,39 +401,63 @@ export default function SpaceTimelinePage() {
             </div>
 
             <div className="mt-8 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <div className="flex items-center gap-2 overflow-x-auto pb-1">{years.map((year) => <button key={year} type="button" onClick={() => jumpToYear(year)} className="shrink-0 rounded-full border border-border bg-background/70 px-4 py-2 text-xs font-medium text-muted-foreground transition hover:border-foreground/20 hover:text-foreground">{year}</button>)}</div>
-              <div className="flex items-center gap-2 overflow-x-auto pb-1 lg:justify-end">{["all", "member_joined", "report", "meeting", "event", "action", "announcement"].map((value) => <button key={value} type="button" onClick={() => setFilter(value)} className={`shrink-0 rounded-full px-4 py-2 text-xs font-medium transition ${filter === value ? "bg-foreground text-background" : "bg-muted text-muted-foreground hover:text-foreground"}`}>{value === "all" ? "Everything" : value === "member_joined" ? "People" : value === "announcement" ? "Updates" : value === "report" ? "Reports" : `${value.charAt(0).toUpperCase()}${value.slice(1)}s`}</button>)}</div>
+              <div className="flex items-center gap-2 overflow-x-auto pb-1">
+                {years.map((year) => <button key={year} type="button" onClick={() => jumpToYear(year)} className="shrink-0 rounded-full border border-border bg-background/70 px-4 py-2 text-xs font-medium text-muted-foreground transition hover:border-foreground/20 hover:text-foreground">{year}</button>)}
+              </div>
+              <div className="flex items-center gap-2 overflow-x-auto pb-1 lg:justify-end">
+                {["all", "member_joined", "report", "meeting", "event", "action", "announcement"].map((value) => (
+                  <button key={value} type="button" onClick={() => setFilter(value)} className={`shrink-0 rounded-full px-4 py-2 text-xs font-medium transition ${filter === value ? "bg-foreground text-background" : "bg-muted text-muted-foreground hover:text-foreground"}`}>
+                    {value === "all" ? "Everything" : value === "member_joined" ? "People" : value === "announcement" ? "Updates" : value === "report" ? "Reports" : `${value.charAt(0).toUpperCase()}${value.slice(1)}s`}
+                  </button>
+                ))}
+              </div>
             </div>
 
-            <div className="mt-6 flex items-center gap-2 overflow-x-auto pb-1">{monthMarkers.map((month, index) => { const palette = paletteFor(index); return <button key={month.key} type="button" onClick={() => jumpToMonth(month.key)} className="flex shrink-0 items-center gap-2 rounded-full border border-border bg-background/70 px-3 py-1.5 text-[11px] font-medium text-muted-foreground transition hover:text-foreground"><span className="h-2 w-2 rounded-full" style={{ backgroundColor: palette.base }} />{month.label}</button>; })}</div>
+            {monthMarkers.length ? (
+              <div className="mt-4 flex items-center gap-2 overflow-x-auto pb-1">
+                {monthMarkers.map((month, index) => {
+                  const color = TIMELINE_COLORS[month.year % TIMELINE_COLORS.length];
+                  return (
+                    <button key={month.key} type="button" onClick={() => jumpToMonth(month.key)} className={`shrink-0 rounded-full border px-3 py-1.5 text-[11px] font-medium transition ${activeMonth === month.key ? "text-foreground shadow-sm" : "text-muted-foreground"}`} style={{ borderColor: color.soft, background: activeMonth === month.key ? color.soft : "transparent" }}>{month.label}</button>
+                  );
+                })}
+              </div>
+            ) : null}
           </section>
 
           <section className="relative flex-1 pb-12">
-            <div ref={railRef} className="scrollbar-hide relative h-[64vh] min-h-[500px] overflow-x-auto overflow-y-hidden px-[7vw] py-6 sm:px-[8vw]">
-              <div className="relative flex min-w-max items-center gap-12 py-20" style={{ minHeight: "100%" }}>
-                <div className="pointer-events-none absolute left-0 right-0 top-1/2 h-[3px] -translate-y-1/2 rounded-full bg-muted/80" />
-                <motion.div className="pointer-events-none absolute left-0 top-1/2 h-[4px] -translate-y-1/2 rounded-full" animate={{ backgroundColor: focusedPalette.base, width: `${((focusIndex + 1) / Math.max(filteredEvents.length, 1)) * 100}%` }} transition={{ duration: 0.7, ease: "easeOut" }} style={{ maxWidth: "100%" }} />
+            <div ref={railRef} className="scrollbar-hide flex h-[64vh] min-h-[500px] items-stretch gap-0 overflow-x-auto overflow-y-hidden px-[7vw] py-6 sm:px-[8vw]">
+              <div className="relative flex min-w-max items-center py-24">
+                <div className="absolute left-0 right-0 top-1/2 h-[3px] rounded-full bg-muted" />
 
-                {filteredEvents.map((event, index) => {
+                {filteredEvents.map((event, eventIndex) => {
                   const date = new Date(event.occurred_at);
                   const monthKey = format(date, "yyyy-MM");
                   const monthIndex = monthMarkers.findIndex((month) => month.key === monthKey);
-                  const palette = paletteFor(monthIndex >= 0 ? monthIndex : index);
-                  const above = index % 2 === 0;
+                  const color = TIMELINE_COLORS[(date.getFullYear() + monthIndex) % TIMELINE_COLORS.length];
                   const imageAttachments = safeArray(event.attachments).filter((item) => item?.mime_type?.startsWith("image/"));
                   const governance = safeArray(event.governance_entities);
                   const governanceCopy = governanceSentence(event, teamName);
-                  const isFocused = index === focusIndex;
+                  const above = eventIndex % 2 === 0;
+                  const isActive = activeMonth === monthKey;
 
                   return (
-                    <div key={event.event_id} data-event-index={index} data-year={date.getFullYear()} data-month={monthKey} className="relative h-[560px] w-[360px] shrink-0 sm:w-[400px]">
-                      <div className="absolute left-1/2 top-1/2 z-0 h-px w-[72px] -translate-y-1/2" style={{ background: `linear-gradient(90deg, transparent, ${palette.base}99)` }} />
-                      <motion.div className="absolute left-1/2 z-0 w-[2px] -translate-x-1/2" animate={{ backgroundColor: isFocused ? palette.base : `${palette.base}77` }} transition={{ duration: 0.3 }} style={above ? { top: "calc(50% - 92px)", height: "92px" } : { top: "50%", height: "92px" }} />
+                    <div key={event.event_id} data-year={date.getFullYear()} className="relative flex h-[560px] w-[410px] shrink-0 flex-col items-center justify-center">
+                      <div className="absolute left-1/2 top-1/2 z-[1] h-[calc(50%-130px)] w-px -translate-x-1/2" style={{ top: above ? undefined : "50%", bottom: above ? "50%" : undefined, background: `linear-gradient(${above ? "to bottom" : "to top"}, ${color.line}, transparent)` }} />
 
-                      <motion.button type="button" onClick={() => setSelectedEvent(event)} className="group absolute left-1/2 z-10 h-[220px] w-[330px] -translate-x-1/2 overflow-hidden rounded-[30px] border border-border/70 bg-muted text-left transition duration-300 hover:-translate-y-1 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary sm:h-[240px] sm:w-[360px]" style={above ? { bottom: "50%", marginBottom: "22px" } : { top: "50%", marginTop: "22px" }} animate={isFocused ? { boxShadow: `0 0 0 2px ${palette.base}35, 0 16px 36px rgba(0,0,0,0.12)` } : { boxShadow: "0 4px 20px rgba(0,0,0,0.06)" }} initial={{ opacity: 0, y: above ? 16 : -16 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true, amount: 0.15 }} transition={{ duration: 0.45, delay: Math.min(index * 0.02, 0.16) }}>
+                      <motion.button
+                        type="button"
+                        onClick={() => setSelectedEvent(event)}
+                        className={`group relative z-10 h-[230px] w-[350px] overflow-hidden rounded-[30px] border bg-muted text-left shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary ${above ? "mb-[205px]" : "mt-[205px]"}`}
+                        style={{ borderColor: isActive ? color.line : "rgba(148,163,184,0.25)", boxShadow: isActive ? `0 0 0 1px ${color.line}, 0 0 28px ${color.soft}` : undefined }}
+                        initial={{ opacity: 0, y: above ? 16 : -16 }}
+                        whileInView={{ opacity: 1, y: 0 }}
+                        viewport={{ once: true, amount: 0.2 }}
+                        transition={{ duration: 0.4, delay: Math.min(eventIndex * 0.025, 0.12) }}
+                      >
                         {imageAttachments.length ? <AutoImageCarousel attachments={imageAttachments} /> : <div className="absolute inset-0 bg-gradient-to-br from-muted via-background to-muted-foreground/10" />}
-                        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/15 to-transparent" />
-                        <div className="absolute left-4 top-4 rounded-full px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.16em] text-white shadow-sm backdrop-blur" style={{ backgroundColor: `${palette.base}dd` }}>{format(date, "d MMM")}</div>
+                        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent transition duration-300 group-hover:from-black/80" />
+                        <div className="absolute left-4 top-4 rounded-full px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-white backdrop-blur" style={{ background: `${color.dark}cc` }}>{format(date, "d MMM")}</div>
                         {governance.length ? <div className="absolute right-4 top-4 flex -space-x-1.5">{governance.slice(0, 3).map((item) => item.image_url ? <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" /> : <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">{(item.short_name || item.label || "G").charAt(0)}</div>)}</div> : null}
                         {event.event_type === "member_joined" ? <div className="absolute left-4 bottom-20 flex items-center gap-2 rounded-full bg-black/35 px-2 py-1.5 text-white backdrop-blur"><Avatar className="h-7 w-7 border border-white/20"><AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} /><AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback></Avatar><span className="max-w-[170px] truncate text-xs font-medium">{event.actor_name || "New member"}</span></div> : null}
                         <div className="absolute inset-x-4 bottom-4 text-white"><div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/70">{pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}</div><div className="mt-1 line-clamp-2 text-lg font-semibold leading-tight">{event.title}</div>{governanceCopy ? <div className="mt-1 line-clamp-1 text-xs text-white/60">{governanceCopy}</div> : null}</div>
@@ -299,6 +465,18 @@ export default function SpaceTimelinePage() {
                     </div>
                   );
                 })}
+
+                <div className="pointer-events-none absolute inset-x-0 top-1/2 z-[2] h-[3px] overflow-hidden rounded-full bg-muted">
+                  {activeMonthIndex >= 0 ? (
+                    <motion.div
+                      className="h-full rounded-full"
+                      initial={false}
+                      animate={{ width: `${Math.max(8, ((activeMonthIndex + 1) / Math.max(monthMarkers.length, 1)) * 100)}%` }}
+                      transition={{ duration: 0.55, ease: "easeOut" }}
+                      style={{ background: `linear-gradient(90deg, ${TIMELINE_COLORS[0].line}, ${TIMELINE_COLORS[(activeMonthIndex + 1) % TIMELINE_COLORS.length].line})` }}
+                    />
+                  ) : null}
+                </div>
               </div>
             </div>
           </section>

--- a/src/pages/space/[space]/timeline.js
+++ b/src/pages/space/[space]/timeline.js
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import { AnimatePresence, motion } from "framer-motion";
 import { ArrowLeft, ArrowRight, ArrowUpRight, History } from "lucide-react";
@@ -24,7 +24,7 @@ const NATURAL_TEXT = {
     "This is where it all came together",
   ],
   member_joined: [
-    "Someone new joined the work",
+    "Someone new joined the team",
     "Another person came on board",
     "The team grew a little stronger",
     "A new contributor joined in",
@@ -32,7 +32,7 @@ const NATURAL_TEXT = {
   ],
   report: [
     "A piece of work took shape",
-    "The Space moved an idea forward",
+    "The team moved an idea forward",
     "Something useful came together",
     "The team put its findings on record",
     "The work turned into something concrete",
@@ -45,29 +45,29 @@ const NATURAL_TEXT = {
     "The team made time to work through the details",
   ],
   event: [
-    "The Space showed up",
+    "The team showed up",
     "The team stepped into the wider conversation",
     "The work met the real world",
-    "The Space took part in the moment",
+    "The team took part in the moment",
     "The team was there for it",
   ],
   action: [
     "Something was done",
-    "The Space moved from words to action",
+    "The team moved from words to action",
     "A small step became a real action",
     "The team followed through",
     "The work moved into the real world",
   ],
   announcement: [
     "Something important was shared",
-    "The Space had an update to share",
+    "The team had an update to share",
     "A new chapter was announced",
     "The team shared where things stood",
     "A useful update made its way out",
   ],
   post: [
     "A moment worth keeping",
-    "Something the Space wanted on record",
+    "Something the team wanted on record",
     "Another piece of the story",
     "A moment from along the way",
     "One more chapter in the journey",
@@ -102,7 +102,7 @@ function naturalLabel(event) {
   return `${pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}: ${title}.`;
 }
 
-function governanceSentence(event) {
+function governanceSentence(event, teamName) {
   const governance = safeArray(event.governance_entities);
   if (!governance.length) return null;
 
@@ -110,21 +110,22 @@ function governanceSentence(event) {
   const name = item.short_name || item.label || "an authority";
   const type = item.entity_type || "authority";
   const phrase = pickVariant(event, GOVERNANCE_TEXT[type] || GOVERNANCE_TEXT.authority);
-
   const relationship = String(item.relationship_type || "").toLowerCase();
+  const actor = teamName || "The team";
+
   if (relationship.includes("respons") || relationship.includes("owner") || relationship.includes("jurisdiction")) {
-    return `This sits ${phrase} ${name}.`;
+    return `${actor} worked under ${name}.`;
   }
 
   if (relationship.includes("collabor") || relationship.includes("partner")) {
-    return `The Space worked alongside ${name}.`;
+    return `${actor} worked alongside ${name}.`;
   }
 
   if (relationship.includes("engag")) {
-    return `The Space was in conversation with ${name}.`;
+    return `${actor} was in conversation with ${name}.`;
   }
 
-  return `The Space worked ${phrase} ${name}.`;
+  return `${actor} worked ${phrase} ${name}.`;
 }
 
 function GovernanceRow({ event, light = false }) {
@@ -154,10 +155,27 @@ function GovernanceRow({ event, light = false }) {
   );
 }
 
-function EventDetail({ event }) {
+function MemberIdentity({ event, light = false }) {
+  if (event.event_type !== "member_joined" || !event.member_user_id) return null;
+
+  return (
+    <div className={`mt-4 flex items-center gap-2 ${light ? "text-white/85" : "text-foreground"}`}>
+      <Avatar className={`h-8 w-8 border ${light ? "border-white/20" : "border-border"}`}>
+        <AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} />
+        <AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback>
+      </Avatar>
+      <div className="min-w-0">
+        <div className="truncate text-sm font-medium">{event.actor_name || "New member"}</div>
+        <div className={`text-[11px] ${light ? "text-white/55" : "text-muted-foreground"}`}>{event.role || "Member"}</div>
+      </div>
+    </div>
+  );
+}
+
+function EventDetail({ event, teamName }) {
   const image = getImage(event);
   const links = safeArray(event.links);
-  const governanceCopy = governanceSentence(event);
+  const governanceCopy = governanceSentence(event, teamName);
 
   return (
     <motion.div
@@ -177,10 +195,11 @@ function EventDetail({ event }) {
             <p className="mt-3 max-w-2xl text-sm leading-6 text-white/75 sm:text-base">
               {event.description || naturalLabel(event)}
             </p>
+            <MemberIdentity event={event} light />
             {governanceCopy ? <p className="mt-3 max-w-2xl text-sm text-white/60">{governanceCopy}</p> : null}
           </div>
 
-          {event.actor_name ? (
+          {event.actor_name && event.event_type !== "member_joined" ? (
             <div className="flex shrink-0 items-center gap-2 text-sm text-white/80">
               <Avatar className="h-8 w-8 border border-white/20">
                 <AvatarImage src={event.actor_avatar} alt="" />
@@ -239,6 +258,24 @@ export default function SpaceTimelinePage() {
   );
 
   const activeEvent = filteredEvents.find((event) => event.event_id === activeId) || null;
+  const teamName = space?.name ? `${space.name} team` : "The team";
+
+  useEffect(() => {
+    const rail = railRef.current;
+    if (!rail) return undefined;
+
+    const handleWheel = (event) => {
+      if (Math.abs(event.deltaY) <= Math.abs(event.deltaX) || Math.abs(event.deltaY) < 2) return;
+      const atStart = rail.scrollLeft <= 0 && event.deltaY < 0;
+      const atEnd = rail.scrollLeft + rail.clientWidth >= rail.scrollWidth - 1 && event.deltaY > 0;
+      if (atStart || atEnd) return;
+      event.preventDefault();
+      rail.scrollLeft += event.deltaY;
+    };
+
+    rail.addEventListener("wheel", handleWheel, { passive: false });
+    return () => rail.removeEventListener("wheel", handleWheel);
+  }, []);
 
   const jump = (direction) => {
     railRef.current?.scrollBy({ left: direction * Math.max(window.innerWidth * 0.72, 460), behavior: "smooth" });
@@ -272,9 +309,9 @@ export default function SpaceTimelinePage() {
           <BackButton />
           <div className="min-w-0 flex-1">
             <div className="truncate text-sm font-medium">{space.name}</div>
-            <div className="text-xs text-muted-foreground">Space history</div>
+            <div className="text-xs text-muted-foreground">The story so far</div>
           </div>
-          <Button variant="ghost" asChild className="rounded-full"><Link href={`/space/${space.slug}`}>Back to Space</Link></Button>
+          <Button variant="ghost" asChild className="rounded-full"><Link href={`/space/${space.slug}`}>Back to {space.name}</Link></Button>
         </header>
 
         <main className="flex min-h-0 flex-1 flex-col">
@@ -283,7 +320,7 @@ export default function SpaceTimelinePage() {
               <div className="max-w-4xl">
                 <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground"><History className="h-3.5 w-3.5" />The story so far</div>
                 <h1 className="mt-4 text-5xl font-semibold tracking-tight sm:text-7xl lg:text-8xl">{space.name}</h1>
-                <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">A visual record of the people, places and moments that shaped this Space.</p>
+                <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">A visual record of the people, places and moments that shaped the {space.name} team.</p>
               </div>
               <div className="flex shrink-0 items-center gap-2"><Button variant="outline" size="icon" className="rounded-full" onClick={() => jump(-1)}><ArrowLeft className="h-4 w-4" /></Button><Button variant="outline" size="icon" className="rounded-full" onClick={() => jump(1)}><ArrowRight className="h-4 w-4" /></Button></div>
             </div>
@@ -311,25 +348,29 @@ export default function SpaceTimelinePage() {
                 const image = getImage(event);
                 const year = new Date(event.occurred_at).getFullYear();
                 const selected = activeId === event.event_id;
-                const governanceCopy = governanceSentence(event);
+                const governanceCopy = governanceSentence(event, teamName);
                 return (
                   <motion.button key={event.event_id} type="button" data-year={year} onClick={() => setActiveId((current) => (current === event.event_id ? null : event.event_id))} className="group relative h-[360px] w-[280px] shrink-0 snap-center overflow-hidden rounded-[30px] border border-border/70 bg-muted text-left shadow-sm transition focus:outline-none focus:ring-2 focus:ring-primary sm:h-[390px] sm:w-[310px] lg:w-[330px]" initial={{ opacity: 0, y: 24 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true, amount: 0.2 }} transition={{ duration: 0.5, delay: Math.min(index * 0.025, 0.18) }}>
                     {image ? <img src={image} alt="" className="absolute inset-0 h-full w-full object-cover transition duration-700 ease-out group-hover:scale-[1.035]" /> : <div className="absolute inset-0 bg-gradient-to-br from-muted via-background to-muted-foreground/10" />}
                     <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/5 to-transparent opacity-80 transition duration-500 group-hover:from-black/70" />
                     <div className="absolute left-5 top-5 rounded-full bg-black/35 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.16em] text-white backdrop-blur">{format(new Date(event.occurred_at), "yyyy")}</div>
 
+                    {event.event_type === "member_joined" && event.actor_name ? (
+                      <div className="absolute right-5 top-5 flex items-center gap-2 rounded-full bg-black/35 px-2 py-1.5 text-white backdrop-blur">
+                        <Avatar className="h-7 w-7 border border-white/25"><AvatarImage src={event.actor_avatar} alt={event.actor_name} /><AvatarFallback>{event.actor_name.charAt(0).toUpperCase()}</AvatarFallback></Avatar>
+                        <span className="max-w-24 truncate text-[10px] font-medium">{event.actor_name}</span>
+                      </div>
+                    ) : safeArray(event.governance_entities).length ? (
+                      <div className="absolute right-5 top-5 flex -space-x-1.5">{safeArray(event.governance_entities).slice(0, 3).map((item) => item.image_url ? <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" /> : <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">{(item.short_name || item.label || "G").charAt(0)}</div>)}</div>
+                    ) : null}
+
                     <div className="absolute inset-x-5 bottom-5 text-white transition duration-300 group-hover:translate-y-[-4px]">
                       <div className="text-xs font-medium uppercase tracking-[0.16em] text-white/70">{pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}</div>
                       <div className="mt-2 line-clamp-2 text-xl font-semibold leading-tight">{event.title}</div>
                       <div className="mt-2 max-h-0 overflow-hidden text-sm leading-6 text-white/75 opacity-0 transition-all duration-300 group-hover:max-h-20 group-hover:opacity-100">{event.description || naturalLabel(event)}</div>
                       {governanceCopy ? <div className="mt-2 max-h-0 overflow-hidden text-xs leading-5 text-white/65 opacity-0 transition-all duration-300 group-hover:max-h-16 group-hover:opacity-100">{governanceCopy}</div> : null}
+                      {event.event_type === "member_joined" ? <MemberIdentity event={event} light /> : null}
                     </div>
-
-                    {safeArray(event.governance_entities).length ? (
-                      <div className="absolute right-5 top-5 flex -space-x-1.5">
-                        {safeArray(event.governance_entities).slice(0, 3).map((item) => item.image_url ? <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" /> : <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">{(item.short_name || item.label || "G").charAt(0)}</div>)}
-                      </div>
-                    ) : null}
 
                     {selected ? <div className="absolute right-5 bottom-5 rounded-full bg-white px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-black shadow-lg">Selected</div> : null}
                   </motion.button>
@@ -337,7 +378,7 @@ export default function SpaceTimelinePage() {
               })}
             </div>
             <div className="pointer-events-none absolute left-[8vw] right-[8vw] top-1/2 hidden h-px -translate-y-1/2 bg-border/70 lg:block" />
-            <AnimatePresence>{activeEvent ? <EventDetail key={activeEvent.event_id} event={activeEvent} /> : null}</AnimatePresence>
+            <AnimatePresence>{activeEvent ? <EventDetail key={activeEvent.event_id} event={activeEvent} teamName={teamName} /> : null}</AnimatePresence>
           </section>
         </main>
       </div>

--- a/src/pages/space/[space]/timeline.js
+++ b/src/pages/space/[space]/timeline.js
@@ -1,0 +1,346 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useRef, useState } from "react";
+import { useRouter } from "next/router";
+import { AnimatePresence, motion } from "framer-motion";
+import { ArrowLeft, ArrowRight, ArrowUpRight, History } from "lucide-react";
+import { format } from "date-fns";
+
+import { useSpaces } from "@/hooks/space/useSpaces";
+import { useSpaceTimeline } from "@/hooks/space/useSpaceTimeline";
+
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import BackButton from "@/components/ui/back-button";
+import PageHeaderSkeleton from "@/components/skeletons/PageHeaderSkeleton";
+
+const TYPE_TEXT = {
+  space_created: "This is where it began",
+  member_joined: "Someone joined the work",
+  report: "A piece of work took shape",
+  meeting: "The team sat down to work through it",
+  event: "The Space showed up",
+  action: "Something was done",
+  announcement: "An important update",
+  post: "A moment worth keeping",
+};
+
+function safeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function getImage(event) {
+  return safeArray(event.attachments).find((item) =>
+    item?.mime_type?.startsWith("image/"),
+  )?.public_url;
+}
+
+function naturalLabel(event) {
+  const title = event.title || "this moment";
+
+  switch (event.event_type) {
+    case "space_created":
+      return `This is where ${title} began.`;
+    case "member_joined":
+      return `${title} joined the work.`;
+    case "report":
+      return `The Space worked on ${title}.`;
+    case "meeting":
+      return `The team met around ${title}.`;
+    case "event":
+      return `The Space took part in ${title}.`;
+    case "action":
+      return `The Space took action on ${title}.`;
+    case "announcement":
+      return `The Space shared an important update: ${title}.`;
+    default:
+      return title;
+  }
+}
+
+function EventDetail({ event }) {
+  const image = getImage(event);
+  const links = safeArray(event.links);
+  const governance = safeArray(event.governance_entities);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -8 }}
+      transition={{ duration: 0.25 }}
+      className="absolute inset-x-4 bottom-4 z-20 sm:inset-x-8 sm:bottom-8"
+    >
+      <div className="mx-auto max-w-4xl rounded-[28px] border border-white/15 bg-black/55 p-5 text-white shadow-2xl backdrop-blur-xl sm:p-7">
+        <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+          <div className="min-w-0">
+            <div className="text-xs font-medium uppercase tracking-[0.18em] text-white/60">
+              {format(new Date(event.occurred_at), "d MMMM yyyy")}
+            </div>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight sm:text-4xl">
+              {event.title}
+            </h2>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-white/75 sm:text-base">
+              {event.description || naturalLabel(event)}
+            </p>
+          </div>
+
+          {event.actor_name ? (
+            <div className="flex shrink-0 items-center gap-2 text-sm text-white/80">
+              <Avatar className="h-8 w-8 border border-white/20">
+                <AvatarImage src={event.actor_avatar} alt="" />
+                <AvatarFallback>{event.actor_name.charAt(0)}</AvatarFallback>
+              </Avatar>
+              <span>{event.actor_name}</span>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="mt-5 flex flex-wrap items-center gap-2 text-xs text-white/70">
+          {governance.slice(0, 4).map((item) => (
+            <span key={item.id} className="rounded-full border border-white/15 bg-white/5 px-3 py-1.5">
+              {item.short_name || item.label}
+            </span>
+          ))}
+
+          {links.slice(0, 2).map((link) => (
+            <a
+              key={link.id}
+              href={link.url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/5 px-3 py-1.5 transition hover:bg-white/10"
+            >
+              {link.hostname || "Source"}
+              <ArrowUpRight className="h-3 w-3" />
+            </a>
+          ))}
+        </div>
+
+        {image ? (
+          <div className="mt-5 overflow-hidden rounded-2xl border border-white/10">
+            <img src={image} alt="" className="max-h-56 w-full object-cover" />
+          </div>
+        ) : null}
+      </div>
+    </motion.div>
+  );
+}
+
+export default function SpaceTimelinePage() {
+  const router = useRouter();
+  const railRef = useRef(null);
+  const { space: slug } = router.query;
+  const { data: space, isLoading, error } = useSpaces({ slug, enabled: !!slug });
+  const { data: timeline = [], isLoading: timelineLoading } = useSpaceTimeline(space?.id);
+
+  const [activeId, setActiveId] = useState(null);
+  const [filter, setFilter] = useState("all");
+
+  const filteredEvents = useMemo(
+    () => timeline.filter((event) => filter === "all" || event.event_type === filter),
+    [timeline, filter],
+  );
+
+  const years = useMemo(
+    () => Array.from(new Set(filteredEvents.map((event) => new Date(event.occurred_at).getFullYear()))).sort((a, b) => a - b),
+    [filteredEvents],
+  );
+
+  const activeEvent = filteredEvents.find((event) => event.event_id === activeId) || null;
+
+  const jump = (direction) => {
+    railRef.current?.scrollBy({ left: direction * Math.max(window.innerWidth * 0.72, 460), behavior: "smooth" });
+  };
+
+  if (isLoading || timelineLoading) {
+    return (
+      <div className="min-h-dvh bg-background">
+        <PageHeaderSkeleton />
+      </div>
+    );
+  }
+
+  if (error || !space) {
+    return (
+      <div className="flex min-h-dvh items-center justify-center bg-background px-6 text-center">
+        <div>
+          <h1 className="text-2xl font-semibold">Space not found</h1>
+          <p className="mt-2 text-muted-foreground">The requested Space does not exist.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative min-h-dvh overflow-hidden bg-background">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <motion.div
+          animate={{ x: [-80, 80, -80], y: [20, -30, 20] }}
+          transition={{ duration: 22, repeat: Infinity, ease: "easeInOut" }}
+          className="absolute left-[-10%] top-[-5%] h-[520px] w-[520px] rounded-full bg-primary/10 blur-[130px]"
+        />
+        <motion.div
+          animate={{ x: [70, -70, 70], y: [0, 50, 0] }}
+          transition={{ duration: 26, repeat: Infinity, ease: "easeInOut" }}
+          className="absolute bottom-[-10%] right-[-8%] h-[480px] w-[480px] rounded-full bg-primary/5 blur-[130px]"
+        />
+        <div
+          className="absolute inset-0 opacity-[0.025]"
+          style={{
+            backgroundImage: `linear-gradient(to right, hsl(var(--foreground)) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--foreground)) 1px, transparent 1px)`,
+            backgroundSize: "64px 64px",
+          }}
+        />
+      </div>
+
+      <div className="relative z-10 flex min-h-dvh flex-col">
+        <header className="flex items-center gap-3 border-b border-border/70 px-4 py-3 sm:px-6 lg:px-8">
+          <BackButton />
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium">{space.name}</div>
+            <div className="text-xs text-muted-foreground">Space history</div>
+          </div>
+          <Button variant="ghost" asChild className="rounded-full">
+            <Link href={`/space/${space.slug}`}>Back to Space</Link>
+          </Button>
+        </header>
+
+        <main className="flex min-h-0 flex-1 flex-col">
+          <section className="mx-auto w-full max-w-7xl px-5 pb-8 pt-10 sm:px-8 sm:pt-16 lg:px-12">
+            <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+              <div className="max-w-4xl">
+                <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                  <History className="h-3.5 w-3.5" />
+                  The story so far
+                </div>
+                <h1 className="mt-4 text-5xl font-semibold tracking-tight sm:text-7xl lg:text-8xl">
+                  {space.name}
+                </h1>
+                <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
+                  A visual record of the people, places and moments that shaped this Space.
+                </p>
+              </div>
+
+              <div className="flex shrink-0 items-center gap-2">
+                <Button variant="outline" size="icon" className="rounded-full" onClick={() => jump(-1)}>
+                  <ArrowLeft className="h-4 w-4" />
+                </Button>
+                <Button variant="outline" size="icon" className="rounded-full" onClick={() => jump(1)}>
+                  <ArrowRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+
+            <div className="mt-8 flex flex-wrap items-center gap-2">
+              {years.map((year) => (
+                <button
+                  key={year}
+                  type="button"
+                  onClick={() => {
+                    const target = railRef.current?.querySelector(`[data-year=\"${year}\"]`);
+                    target?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+                  }}
+                  className="rounded-full border border-border bg-background/70 px-4 py-2 text-xs font-medium text-muted-foreground transition hover:border-foreground/20 hover:text-foreground"
+                >
+                  {year}
+                </button>
+              ))}
+            </div>
+
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              {["all", "member_joined", "report", "meeting", "event", "action", "announcement"].map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setFilter(value)}
+                  className={`rounded-full px-4 py-2 text-xs font-medium transition ${
+                    filter === value
+                      ? "bg-foreground text-background"
+                      : "bg-muted text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  {value === "all"
+                    ? "Everything"
+                    : value === "member_joined"
+                      ? "People"
+                      : value === "announcement"
+                        ? "Updates"
+                        : value.charAt(0).toUpperCase() + value.slice(1) + (value === "report" ? "s" : "s")}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="relative flex-1 pb-12">
+            <div
+              ref={railRef}
+              className="scrollbar-hide flex h-[58vh] min-h-[430px] snap-x items-center gap-8 overflow-x-auto overflow-y-hidden px-[8vw] py-10"
+            >
+              {filteredEvents.map((event, index) => {
+                const image = getImage(event);
+                const year = new Date(event.occurred_at).getFullYear();
+                const selected = activeId === event.event_id;
+
+                return (
+                  <motion.button
+                    key={event.event_id}
+                    type="button"
+                    data-year={year}
+                    onClick={() => setActiveId((current) => (current === event.event_id ? null : event.event_id))}
+                    className="group relative h-[360px] w-[280px] shrink-0 snap-center overflow-hidden rounded-[30px] border border-border/70 bg-muted text-left shadow-sm transition focus:outline-none focus:ring-2 focus:ring-primary sm:h-[390px] sm:w-[310px] lg:w-[330px]"
+                    initial={{ opacity: 0, y: 24 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true, amount: 0.2 }}
+                    transition={{ duration: 0.5, delay: Math.min(index * 0.025, 0.18) }}
+                  >
+                    {image ? (
+                      <img
+                        src={image}
+                        alt=""
+                        className="absolute inset-0 h-full w-full object-cover transition duration-700 ease-out group-hover:scale-[1.035]"
+                      />
+                    ) : (
+                      <div className="absolute inset-0 bg-gradient-to-br from-muted via-background to-muted-foreground/10" />
+                    )}
+
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/5 to-transparent opacity-80 transition duration-500 group-hover:from-black/70" />
+
+                    <div className="absolute left-5 top-5 rounded-full bg-black/35 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.16em] text-white backdrop-blur">
+                      {format(new Date(event.occurred_at), "yyyy")}
+                    </div>
+
+                    <div className="absolute inset-x-5 bottom-5 text-white transition duration-300 group-hover:translate-y-[-4px]">
+                      <div className="text-xs font-medium uppercase tracking-[0.16em] text-white/70">
+                        {TYPE_TEXT[event.event_type] || "A moment worth keeping"}
+                      </div>
+                      <div className="mt-2 line-clamp-2 text-xl font-semibold leading-tight">
+                        {event.title}
+                      </div>
+                      <div className="mt-2 max-h-0 overflow-hidden text-sm leading-6 text-white/75 opacity-0 transition-all duration-300 group-hover:max-h-20 group-hover:opacity-100">
+                        {event.description || naturalLabel(event)}
+                      </div>
+                    </div>
+
+                    {selected ? (
+                      <div className="absolute right-5 top-5 rounded-full bg-white px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-black shadow-lg">
+                        Selected
+                      </div>
+                    ) : null}
+                  </motion.button>
+                );
+              })}
+            </div>
+
+            <div className="pointer-events-none absolute left-[8vw] right-[8vw] top-1/2 hidden h-px -translate-y-1/2 bg-border/70 lg:block" />
+
+            <AnimatePresence>
+              {activeEvent ? <EventDetail key={activeEvent.event_id} event={activeEvent} /> : null}
+            </AnimatePresence>
+          </section>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/space/[space]/timeline.js
+++ b/src/pages/space/[space]/timeline.js
@@ -15,15 +15,71 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import BackButton from "@/components/ui/back-button";
 import PageHeaderSkeleton from "@/components/skeletons/PageHeaderSkeleton";
 
-const TYPE_TEXT = {
-  space_created: "This is where it began",
-  member_joined: "Someone joined the work",
-  report: "A piece of work took shape",
-  meeting: "The team sat down to work through it",
-  event: "The Space showed up",
-  action: "Something was done",
-  announcement: "An important update",
-  post: "A moment worth keeping",
+const NATURAL_TEXT = {
+  space_created: [
+    "This is where the story began",
+    "This is where the work started",
+    "The first page of the story",
+    "The beginning of something local",
+    "This is where it all came together",
+  ],
+  member_joined: [
+    "Someone new joined the work",
+    "Another person came on board",
+    "The team grew a little stronger",
+    "A new contributor joined in",
+    "Another pair of hands joined the effort",
+  ],
+  report: [
+    "A piece of work took shape",
+    "The Space moved an idea forward",
+    "Something useful came together",
+    "The team put its findings on record",
+    "The work turned into something concrete",
+  ],
+  meeting: [
+    "The team sat down to work through it",
+    "People came together to figure it out",
+    "A conversation moved the work forward",
+    "The right people got around the table",
+    "The team made time to work through the details",
+  ],
+  event: [
+    "The Space showed up",
+    "The team stepped into the wider conversation",
+    "The work met the real world",
+    "The Space took part in the moment",
+    "The team was there for it",
+  ],
+  action: [
+    "Something was done",
+    "The Space moved from words to action",
+    "A small step became a real action",
+    "The team followed through",
+    "The work moved into the real world",
+  ],
+  announcement: [
+    "Something important was shared",
+    "The Space had an update to share",
+    "A new chapter was announced",
+    "The team shared where things stood",
+    "A useful update made its way out",
+  ],
+  post: [
+    "A moment worth keeping",
+    "Something the Space wanted on record",
+    "Another piece of the story",
+    "A moment from along the way",
+    "One more chapter in the journey",
+  ],
+};
+
+const GOVERNANCE_TEXT = {
+  authority: ["under", "with", "in conversation with"],
+  department: ["within", "through", "with"],
+  official: ["with", "in conversation with", "alongside"],
+  organization: ["alongside", "with", "working with"],
+  person: ["with", "alongside", "in conversation with"],
 };
 
 function safeArray(value) {
@@ -31,38 +87,77 @@ function safeArray(value) {
 }
 
 function getImage(event) {
-  return safeArray(event.attachments).find((item) =>
-    item?.mime_type?.startsWith("image/"),
-  )?.public_url;
+  return safeArray(event.attachments).find((item) => item?.mime_type?.startsWith("image/"))?.public_url;
+}
+
+function pickVariant(event, items) {
+  const key = String(event.event_id || event.post_id || event.title || "timeline");
+  let hash = 0;
+  for (let index = 0; index < key.length; index += 1) hash = (hash * 31 + key.charCodeAt(index)) >>> 0;
+  return items[hash % items.length];
 }
 
 function naturalLabel(event) {
   const title = event.title || "this moment";
+  return `${pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}: ${title}.`;
+}
 
-  switch (event.event_type) {
-    case "space_created":
-      return `This is where ${title} began.`;
-    case "member_joined":
-      return `${title} joined the work.`;
-    case "report":
-      return `The Space worked on ${title}.`;
-    case "meeting":
-      return `The team met around ${title}.`;
-    case "event":
-      return `The Space took part in ${title}.`;
-    case "action":
-      return `The Space took action on ${title}.`;
-    case "announcement":
-      return `The Space shared an important update: ${title}.`;
-    default:
-      return title;
+function governanceSentence(event) {
+  const governance = safeArray(event.governance_entities);
+  if (!governance.length) return null;
+
+  const item = governance[0];
+  const name = item.short_name || item.label || "an authority";
+  const type = item.entity_type || "authority";
+  const phrase = pickVariant(event, GOVERNANCE_TEXT[type] || GOVERNANCE_TEXT.authority);
+
+  const relationship = String(item.relationship_type || "").toLowerCase();
+  if (relationship.includes("respons") || relationship.includes("owner") || relationship.includes("jurisdiction")) {
+    return `This sits ${phrase} ${name}.`;
   }
+
+  if (relationship.includes("collabor") || relationship.includes("partner")) {
+    return `The Space worked alongside ${name}.`;
+  }
+
+  if (relationship.includes("engag")) {
+    return `The Space was in conversation with ${name}.`;
+  }
+
+  return `The Space worked ${phrase} ${name}.`;
+}
+
+function GovernanceRow({ event, light = false }) {
+  const governance = safeArray(event.governance_entities);
+  if (!governance.length) return null;
+
+  return (
+    <div className={`mt-5 flex flex-wrap items-center gap-2 ${light ? "text-white/80" : "text-muted-foreground"}`}>
+      {governance.slice(0, 4).map((item) => (
+        <div
+          key={item.id}
+          className={`flex items-center gap-2 rounded-full border px-2.5 py-1.5 backdrop-blur ${
+            light ? "border-white/15 bg-white/5" : "border-border bg-background/70"
+          }`}
+        >
+          {item.image_url ? (
+            <img src={item.image_url} alt="" className="h-5 w-5 rounded-full object-contain" />
+          ) : (
+            <div className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[9px] font-semibold">
+              {(item.short_name || item.label || "G").charAt(0)}
+            </div>
+          )}
+          <span className="max-w-32 truncate text-[11px] font-medium">{item.short_name || item.label}</span>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 function EventDetail({ event }) {
   const image = getImage(event);
   const links = safeArray(event.links);
-  const governance = safeArray(event.governance_entities);
+  const governanceCopy = governanceSentence(event);
 
   return (
     <motion.div
@@ -78,12 +173,11 @@ function EventDetail({ event }) {
             <div className="text-xs font-medium uppercase tracking-[0.18em] text-white/60">
               {format(new Date(event.occurred_at), "d MMMM yyyy")}
             </div>
-            <h2 className="mt-2 text-2xl font-semibold tracking-tight sm:text-4xl">
-              {event.title}
-            </h2>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight sm:text-4xl">{event.title}</h2>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-white/75 sm:text-base">
               {event.description || naturalLabel(event)}
             </p>
+            {governanceCopy ? <p className="mt-3 max-w-2xl text-sm text-white/60">{governanceCopy}</p> : null}
           </div>
 
           {event.actor_name ? (
@@ -97,13 +191,9 @@ function EventDetail({ event }) {
           ) : null}
         </div>
 
-        <div className="mt-5 flex flex-wrap items-center gap-2 text-xs text-white/70">
-          {governance.slice(0, 4).map((item) => (
-            <span key={item.id} className="rounded-full border border-white/15 bg-white/5 px-3 py-1.5">
-              {item.short_name || item.label}
-            </span>
-          ))}
+        <GovernanceRow event={event} light />
 
+        <div className="mt-5 flex flex-wrap items-center gap-2 text-xs text-white/70">
           {links.slice(0, 2).map((link) => (
             <a
               key={link.id}
@@ -155,11 +245,7 @@ export default function SpaceTimelinePage() {
   };
 
   if (isLoading || timelineLoading) {
-    return (
-      <div className="min-h-dvh bg-background">
-        <PageHeaderSkeleton />
-      </div>
-    );
+    return <div className="min-h-dvh bg-background"><PageHeaderSkeleton /></div>;
   }
 
   if (error || !space) {
@@ -176,23 +262,9 @@ export default function SpaceTimelinePage() {
   return (
     <div className="relative min-h-dvh overflow-hidden bg-background">
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <motion.div
-          animate={{ x: [-80, 80, -80], y: [20, -30, 20] }}
-          transition={{ duration: 22, repeat: Infinity, ease: "easeInOut" }}
-          className="absolute left-[-10%] top-[-5%] h-[520px] w-[520px] rounded-full bg-primary/10 blur-[130px]"
-        />
-        <motion.div
-          animate={{ x: [70, -70, 70], y: [0, 50, 0] }}
-          transition={{ duration: 26, repeat: Infinity, ease: "easeInOut" }}
-          className="absolute bottom-[-10%] right-[-8%] h-[480px] w-[480px] rounded-full bg-primary/5 blur-[130px]"
-        />
-        <div
-          className="absolute inset-0 opacity-[0.025]"
-          style={{
-            backgroundImage: `linear-gradient(to right, hsl(var(--foreground)) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--foreground)) 1px, transparent 1px)`,
-            backgroundSize: "64px 64px",
-          }}
-        />
+        <motion.div animate={{ x: [-80, 80, -80], y: [20, -30, 20] }} transition={{ duration: 22, repeat: Infinity, ease: "easeInOut" }} className="absolute left-[-10%] top-[-5%] h-[520px] w-[520px] rounded-full bg-primary/10 blur-[130px]" />
+        <motion.div animate={{ x: [70, -70, 70], y: [0, 50, 0] }} transition={{ duration: 26, repeat: Infinity, ease: "easeInOut" }} className="absolute bottom-[-10%] right-[-8%] h-[480px] w-[480px] rounded-full bg-primary/5 blur-[130px]" />
+        <div className="absolute inset-0 opacity-[0.025]" style={{ backgroundImage: `linear-gradient(to right, hsl(var(--foreground)) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--foreground)) 1px, transparent 1px)`, backgroundSize: "64px 64px" }} />
       </div>
 
       <div className="relative z-10 flex min-h-dvh flex-col">
@@ -202,142 +274,70 @@ export default function SpaceTimelinePage() {
             <div className="truncate text-sm font-medium">{space.name}</div>
             <div className="text-xs text-muted-foreground">Space history</div>
           </div>
-          <Button variant="ghost" asChild className="rounded-full">
-            <Link href={`/space/${space.slug}`}>Back to Space</Link>
-          </Button>
+          <Button variant="ghost" asChild className="rounded-full"><Link href={`/space/${space.slug}`}>Back to Space</Link></Button>
         </header>
 
         <main className="flex min-h-0 flex-1 flex-col">
           <section className="mx-auto w-full max-w-7xl px-5 pb-8 pt-10 sm:px-8 sm:pt-16 lg:px-12">
             <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
               <div className="max-w-4xl">
-                <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                  <History className="h-3.5 w-3.5" />
-                  The story so far
-                </div>
-                <h1 className="mt-4 text-5xl font-semibold tracking-tight sm:text-7xl lg:text-8xl">
-                  {space.name}
-                </h1>
-                <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
-                  A visual record of the people, places and moments that shaped this Space.
-                </p>
+                <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground"><History className="h-3.5 w-3.5" />The story so far</div>
+                <h1 className="mt-4 text-5xl font-semibold tracking-tight sm:text-7xl lg:text-8xl">{space.name}</h1>
+                <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">A visual record of the people, places and moments that shaped this Space.</p>
               </div>
-
-              <div className="flex shrink-0 items-center gap-2">
-                <Button variant="outline" size="icon" className="rounded-full" onClick={() => jump(-1)}>
-                  <ArrowLeft className="h-4 w-4" />
-                </Button>
-                <Button variant="outline" size="icon" className="rounded-full" onClick={() => jump(1)}>
-                  <ArrowRight className="h-4 w-4" />
-                </Button>
-              </div>
+              <div className="flex shrink-0 items-center gap-2"><Button variant="outline" size="icon" className="rounded-full" onClick={() => jump(-1)}><ArrowLeft className="h-4 w-4" /></Button><Button variant="outline" size="icon" className="rounded-full" onClick={() => jump(1)}><ArrowRight className="h-4 w-4" /></Button></div>
             </div>
 
-            <div className="mt-8 flex flex-wrap items-center gap-2">
-              {years.map((year) => (
-                <button
-                  key={year}
-                  type="button"
-                  onClick={() => {
-                    const target = railRef.current?.querySelector(`[data-year=\"${year}\"]`);
-                    target?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
-                  }}
-                  className="rounded-full border border-border bg-background/70 px-4 py-2 text-xs font-medium text-muted-foreground transition hover:border-foreground/20 hover:text-foreground"
-                >
-                  {year}
-                </button>
-              ))}
-            </div>
+            <div className="mt-8 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex items-center gap-2 overflow-x-auto pb-1">
+                {years.map((year) => (
+                  <button key={year} type="button" onClick={() => railRef.current?.querySelector(`[data-year="${year}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" })} className="rounded-full border border-border bg-background/70 px-4 py-2 text-xs font-medium text-muted-foreground transition hover:border-foreground/20 hover:text-foreground">{year}</button>
+                ))}
+              </div>
 
-            <div className="mt-3 flex flex-wrap items-center gap-2">
-              {["all", "member_joined", "report", "meeting", "event", "action", "announcement"].map((value) => (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => setFilter(value)}
-                  className={`rounded-full px-4 py-2 text-xs font-medium transition ${
-                    filter === value
-                      ? "bg-foreground text-background"
-                      : "bg-muted text-muted-foreground hover:text-foreground"
-                  }`}
-                >
-                  {value === "all"
-                    ? "Everything"
-                    : value === "member_joined"
-                      ? "People"
-                      : value === "announcement"
-                        ? "Updates"
-                        : value.charAt(0).toUpperCase() + value.slice(1) + (value === "report" ? "s" : "s")}
-                </button>
-              ))}
+              <div className="flex items-center gap-2 overflow-x-auto pb-1 lg:justify-end">
+                {["all", "member_joined", "report", "meeting", "event", "action", "announcement"].map((value) => (
+                  <button key={value} type="button" onClick={() => setFilter(value)} className={`shrink-0 rounded-full px-4 py-2 text-xs font-medium transition ${filter === value ? "bg-foreground text-background" : "bg-muted text-muted-foreground hover:text-foreground"}`}>
+                    {value === "all" ? "Everything" : value === "member_joined" ? "People" : value === "announcement" ? "Updates" : value === "report" ? "Reports" : `${value.charAt(0).toUpperCase()}${value.slice(1)}s`}
+                  </button>
+                ))}
+              </div>
             </div>
           </section>
 
           <section className="relative flex-1 pb-12">
-            <div
-              ref={railRef}
-              className="scrollbar-hide flex h-[58vh] min-h-[430px] snap-x items-center gap-8 overflow-x-auto overflow-y-hidden px-[8vw] py-10"
-            >
+            <div ref={railRef} className="scrollbar-hide flex h-[58vh] min-h-[430px] snap-x items-center gap-8 overflow-x-auto overflow-y-hidden px-[8vw] py-10">
               {filteredEvents.map((event, index) => {
                 const image = getImage(event);
                 const year = new Date(event.occurred_at).getFullYear();
                 const selected = activeId === event.event_id;
-
+                const governanceCopy = governanceSentence(event);
                 return (
-                  <motion.button
-                    key={event.event_id}
-                    type="button"
-                    data-year={year}
-                    onClick={() => setActiveId((current) => (current === event.event_id ? null : event.event_id))}
-                    className="group relative h-[360px] w-[280px] shrink-0 snap-center overflow-hidden rounded-[30px] border border-border/70 bg-muted text-left shadow-sm transition focus:outline-none focus:ring-2 focus:ring-primary sm:h-[390px] sm:w-[310px] lg:w-[330px]"
-                    initial={{ opacity: 0, y: 24 }}
-                    whileInView={{ opacity: 1, y: 0 }}
-                    viewport={{ once: true, amount: 0.2 }}
-                    transition={{ duration: 0.5, delay: Math.min(index * 0.025, 0.18) }}
-                  >
-                    {image ? (
-                      <img
-                        src={image}
-                        alt=""
-                        className="absolute inset-0 h-full w-full object-cover transition duration-700 ease-out group-hover:scale-[1.035]"
-                      />
-                    ) : (
-                      <div className="absolute inset-0 bg-gradient-to-br from-muted via-background to-muted-foreground/10" />
-                    )}
-
+                  <motion.button key={event.event_id} type="button" data-year={year} onClick={() => setActiveId((current) => (current === event.event_id ? null : event.event_id))} className="group relative h-[360px] w-[280px] shrink-0 snap-center overflow-hidden rounded-[30px] border border-border/70 bg-muted text-left shadow-sm transition focus:outline-none focus:ring-2 focus:ring-primary sm:h-[390px] sm:w-[310px] lg:w-[330px]" initial={{ opacity: 0, y: 24 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true, amount: 0.2 }} transition={{ duration: 0.5, delay: Math.min(index * 0.025, 0.18) }}>
+                    {image ? <img src={image} alt="" className="absolute inset-0 h-full w-full object-cover transition duration-700 ease-out group-hover:scale-[1.035]" /> : <div className="absolute inset-0 bg-gradient-to-br from-muted via-background to-muted-foreground/10" />}
                     <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/5 to-transparent opacity-80 transition duration-500 group-hover:from-black/70" />
-
-                    <div className="absolute left-5 top-5 rounded-full bg-black/35 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.16em] text-white backdrop-blur">
-                      {format(new Date(event.occurred_at), "yyyy")}
-                    </div>
+                    <div className="absolute left-5 top-5 rounded-full bg-black/35 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.16em] text-white backdrop-blur">{format(new Date(event.occurred_at), "yyyy")}</div>
 
                     <div className="absolute inset-x-5 bottom-5 text-white transition duration-300 group-hover:translate-y-[-4px]">
-                      <div className="text-xs font-medium uppercase tracking-[0.16em] text-white/70">
-                        {TYPE_TEXT[event.event_type] || "A moment worth keeping"}
-                      </div>
-                      <div className="mt-2 line-clamp-2 text-xl font-semibold leading-tight">
-                        {event.title}
-                      </div>
-                      <div className="mt-2 max-h-0 overflow-hidden text-sm leading-6 text-white/75 opacity-0 transition-all duration-300 group-hover:max-h-20 group-hover:opacity-100">
-                        {event.description || naturalLabel(event)}
-                      </div>
+                      <div className="text-xs font-medium uppercase tracking-[0.16em] text-white/70">{pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}</div>
+                      <div className="mt-2 line-clamp-2 text-xl font-semibold leading-tight">{event.title}</div>
+                      <div className="mt-2 max-h-0 overflow-hidden text-sm leading-6 text-white/75 opacity-0 transition-all duration-300 group-hover:max-h-20 group-hover:opacity-100">{event.description || naturalLabel(event)}</div>
+                      {governanceCopy ? <div className="mt-2 max-h-0 overflow-hidden text-xs leading-5 text-white/65 opacity-0 transition-all duration-300 group-hover:max-h-16 group-hover:opacity-100">{governanceCopy}</div> : null}
                     </div>
 
-                    {selected ? (
-                      <div className="absolute right-5 top-5 rounded-full bg-white px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-black shadow-lg">
-                        Selected
+                    {safeArray(event.governance_entities).length ? (
+                      <div className="absolute right-5 top-5 flex -space-x-1.5">
+                        {safeArray(event.governance_entities).slice(0, 3).map((item) => item.image_url ? <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" /> : <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">{(item.short_name || item.label || "G").charAt(0)}</div>)}
                       </div>
                     ) : null}
+
+                    {selected ? <div className="absolute right-5 bottom-5 rounded-full bg-white px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-black shadow-lg">Selected</div> : null}
                   </motion.button>
                 );
               })}
             </div>
-
             <div className="pointer-events-none absolute left-[8vw] right-[8vw] top-1/2 hidden h-px -translate-y-1/2 bg-border/70 lg:block" />
-
-            <AnimatePresence>
-              {activeEvent ? <EventDetail key={activeEvent.event_id} event={activeEvent} /> : null}
-            </AnimatePresence>
+            <AnimatePresence>{activeEvent ? <EventDetail key={activeEvent.event_id} event={activeEvent} /> : null}</AnimatePresence>
           </section>
         </main>
       </div>

--- a/src/pages/space/[space]/timeline.js
+++ b/src/pages/space/[space]/timeline.js
@@ -12,8 +12,15 @@ import { useSpaceTimeline } from "@/hooks/space/useSpaceTimeline";
 
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import BackButton from "@/components/ui/back-button";
 import PageHeaderSkeleton from "@/components/skeletons/PageHeaderSkeleton";
+import AutoImageCarousel from "@/components/attachment/AutoImageCarousel";
 
 const NATURAL_TEXT = {
   space_created: [
@@ -86,14 +93,14 @@ function safeArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
-function getImage(event) {
-  return safeArray(event.attachments).find((item) => item?.mime_type?.startsWith("image/"))?.public_url;
-}
-
 function pickVariant(event, items) {
   const key = String(event.event_id || event.post_id || event.title || "timeline");
   let hash = 0;
-  for (let index = 0; index < key.length; index += 1) hash = (hash * 31 + key.charCodeAt(index)) >>> 0;
+
+  for (let index = 0; index < key.length; index += 1) {
+    hash = (hash * 31 + key.charCodeAt(index)) >>> 0;
+  }
+
   return items[hash % items.length];
 }
 
@@ -109,15 +116,25 @@ function governanceSentence(event, teamName) {
   const item = governance[0];
   const name = item.short_name || item.label || "an authority";
   const type = item.entity_type || "authority";
-  const phrase = pickVariant(event, GOVERNANCE_TEXT[type] || GOVERNANCE_TEXT.authority);
+  const phrase = pickVariant(
+    event,
+    GOVERNANCE_TEXT[type] || GOVERNANCE_TEXT.authority,
+  );
   const relationship = String(item.relationship_type || "").toLowerCase();
   const actor = teamName || "The team";
 
-  if (relationship.includes("respons") || relationship.includes("owner") || relationship.includes("jurisdiction")) {
+  if (
+    relationship.includes("respons") ||
+    relationship.includes("owner") ||
+    relationship.includes("jurisdiction")
+  ) {
     return `${actor} worked under ${name}.`;
   }
 
-  if (relationship.includes("collabor") || relationship.includes("partner")) {
+  if (
+    relationship.includes("collabor") ||
+    relationship.includes("partner")
+  ) {
     return `${actor} worked alongside ${name}.`;
   }
 
@@ -128,112 +145,170 @@ function governanceSentence(event, teamName) {
   return `${actor} worked ${phrase} ${name}.`;
 }
 
+function MemberIdentity({ event, light = false }) {
+  if (event.event_type !== "member_joined") return null;
+
+  return (
+    <div
+      className={`flex items-center gap-2 ${
+        light ? "text-white/85" : "text-foreground"
+      }`}
+    >
+      <Avatar
+        className={`h-9 w-9 border ${
+          light ? "border-white/20" : "border-border"
+        }`}
+      >
+        <AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} />
+        <AvatarFallback>
+          {event.actor_name?.charAt(0)?.toUpperCase() || "U"}
+        </AvatarFallback>
+      </Avatar>
+      <div className="min-w-0">
+        <div className="truncate text-sm font-medium">
+          {event.actor_name || "New member"}
+        </div>
+        <div
+          className={`text-[11px] ${
+            light ? "text-white/55" : "text-muted-foreground"
+          }`}
+        >
+          {event.role || "Member"}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function GovernanceRow({ event, light = false }) {
   const governance = safeArray(event.governance_entities);
   if (!governance.length) return null;
 
   return (
-    <div className={`mt-5 flex flex-wrap items-center gap-2 ${light ? "text-white/80" : "text-muted-foreground"}`}>
+    <div
+      className={`flex flex-wrap items-center gap-2 ${
+        light ? "text-white/80" : "text-muted-foreground"
+      }`}
+    >
       {governance.slice(0, 4).map((item) => (
         <div
           key={item.id}
           className={`flex items-center gap-2 rounded-full border px-2.5 py-1.5 backdrop-blur ${
-            light ? "border-white/15 bg-white/5" : "border-border bg-background/70"
+            light
+              ? "border-white/15 bg-white/5"
+              : "border-border bg-background/70"
           }`}
         >
           {item.image_url ? (
-            <img src={item.image_url} alt="" className="h-5 w-5 rounded-full object-contain" />
+            <img
+              src={item.image_url}
+              alt=""
+              className="h-5 w-5 rounded-full object-contain"
+            />
           ) : (
             <div className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[9px] font-semibold">
               {(item.short_name || item.label || "G").charAt(0)}
             </div>
           )}
-          <span className="max-w-32 truncate text-[11px] font-medium">{item.short_name || item.label}</span>
+          <span className="max-w-32 truncate text-[11px] font-medium">
+            {item.short_name || item.label}
+          </span>
         </div>
       ))}
     </div>
   );
 }
 
-function MemberIdentity({ event, light = false }) {
-  if (event.event_type !== "member_joined" || !event.member_user_id) return null;
-
-  return (
-    <div className={`mt-4 flex items-center gap-2 ${light ? "text-white/85" : "text-foreground"}`}>
-      <Avatar className={`h-8 w-8 border ${light ? "border-white/20" : "border-border"}`}>
-        <AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} />
-        <AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback>
-      </Avatar>
-      <div className="min-w-0">
-        <div className="truncate text-sm font-medium">{event.actor_name || "New member"}</div>
-        <div className={`text-[11px] ${light ? "text-white/55" : "text-muted-foreground"}`}>{event.role || "Member"}</div>
-      </div>
-    </div>
+function EventDialog({ event, teamName, open, onOpenChange }) {
+  const imageAttachments = safeArray(event.attachments).filter((item) =>
+    item?.mime_type?.startsWith("image/"),
   );
-}
-
-function EventDetail({ event, teamName }) {
-  const image = getImage(event);
   const links = safeArray(event.links);
   const governanceCopy = governanceSentence(event, teamName);
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: -8 }}
-      transition={{ duration: 0.25 }}
-      className="absolute inset-x-4 bottom-4 z-20 sm:inset-x-8 sm:bottom-8"
-    >
-      <div className="mx-auto max-w-4xl rounded-[28px] border border-white/15 bg-black/55 p-5 text-white shadow-2xl backdrop-blur-xl sm:p-7">
-        <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
-          <div className="min-w-0">
-            <div className="text-xs font-medium uppercase tracking-[0.18em] text-white/60">
-              {format(new Date(event.occurred_at), "d MMMM yyyy")}
-            </div>
-            <h2 className="mt-2 text-2xl font-semibold tracking-tight sm:text-4xl">{event.title}</h2>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-white/75 sm:text-base">
-              {event.description || naturalLabel(event)}
-            </p>
-            <MemberIdentity event={event} light />
-            {governanceCopy ? <p className="mt-3 max-w-2xl text-sm text-white/60">{governanceCopy}</p> : null}
-          </div>
-
-          {event.actor_name && event.event_type !== "member_joined" ? (
-            <div className="flex shrink-0 items-center gap-2 text-sm text-white/80">
-              <Avatar className="h-8 w-8 border border-white/20">
-                <AvatarImage src={event.actor_avatar} alt="" />
-                <AvatarFallback>{event.actor_name.charAt(0)}</AvatarFallback>
-              </Avatar>
-              <span>{event.actor_name}</span>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[88vh] max-w-4xl overflow-y-auto rounded-[30px] border bg-background p-0">
+        <div className="overflow-hidden rounded-[30px]">
+          {imageAttachments.length ? (
+            <div className="relative h-[260px] overflow-hidden bg-muted sm:h-[380px]">
+              <AutoImageCarousel attachments={imageAttachments} />
+              <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black/70 to-transparent" />
+              <div className="absolute inset-x-6 bottom-5 text-white sm:inset-x-8">
+                <div className="text-xs font-medium uppercase tracking-[0.18em] text-white/70">
+                  {format(new Date(event.occurred_at), "d MMMM yyyy")}
+                </div>
+                <DialogTitle className="mt-2 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                  {event.title}
+                </DialogTitle>
+              </div>
             </div>
           ) : null}
-        </div>
 
-        <GovernanceRow event={event} light />
+          <div className="space-y-5 p-6 sm:p-8">
+            {!imageAttachments.length ? (
+              <div>
+                <div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                  {format(new Date(event.occurred_at), "d MMMM yyyy")}
+                </div>
+                <DialogTitle className="mt-2 text-3xl font-semibold tracking-tight sm:text-4xl">
+                  {event.title}
+                </DialogTitle>
+              </div>
+            ) : null}
 
-        <div className="mt-5 flex flex-wrap items-center gap-2 text-xs text-white/70">
-          {links.slice(0, 2).map((link) => (
-            <a
-              key={link.id}
-              href={link.url}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/5 px-3 py-1.5 transition hover:bg-white/10"
-            >
-              {link.hostname || "Source"}
-              <ArrowUpRight className="h-3 w-3" />
-            </a>
-          ))}
-        </div>
+            <DialogDescription className="text-base leading-7 text-muted-foreground">
+              {event.description || naturalLabel(event)}
+            </DialogDescription>
 
-        {image ? (
-          <div className="mt-5 overflow-hidden rounded-2xl border border-white/10">
-            <img src={image} alt="" className="max-h-56 w-full object-cover" />
+            {event.event_type === "member_joined" ? (
+              <MemberIdentity event={event} />
+            ) : event.actor_name ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Avatar className="h-8 w-8 border">
+                  <AvatarImage src={event.actor_avatar} alt={event.actor_name} />
+                  <AvatarFallback>
+                    {event.actor_name.charAt(0).toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+                <span>{event.actor_name}</span>
+              </div>
+            ) : null}
+
+            {governanceCopy ? (
+              <p className="text-sm leading-6 text-muted-foreground">
+                {governanceCopy}
+              </p>
+            ) : null}
+
+            <GovernanceRow event={event} />
+
+            {event.address ? (
+              <div className="rounded-2xl border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+                {event.address}
+              </div>
+            ) : null}
+
+            {links.length ? (
+              <div className="flex flex-wrap gap-2">
+                {links.slice(0, 4).map((link) => (
+                  <a
+                    key={link.id}
+                    href={link.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center gap-1.5 rounded-full border bg-background px-3 py-2 text-xs font-medium transition hover:bg-muted"
+                  >
+                    {link.hostname || link.title || "Source"}
+                    <ArrowUpRight className="h-3.5 w-3.5" />
+                  </a>
+                ))}
+              </div>
+            ) : null}
           </div>
-        ) : null}
-      </div>
-    </motion.div>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -241,23 +316,63 @@ export default function SpaceTimelinePage() {
   const router = useRouter();
   const railRef = useRef(null);
   const { space: slug } = router.query;
-  const { data: space, isLoading, error } = useSpaces({ slug, enabled: !!slug });
-  const { data: timeline = [], isLoading: timelineLoading } = useSpaceTimeline(space?.id);
+
+  const { data: space, isLoading, error } = useSpaces({
+    slug,
+    enabled: !!slug,
+  });
+
+  const { data: timeline = [], isLoading: timelineLoading } = useSpaceTimeline(
+    space?.id,
+  );
 
   const [activeId, setActiveId] = useState(null);
   const [filter, setFilter] = useState("all");
+  const [selectedEvent, setSelectedEvent] = useState(null);
 
   const filteredEvents = useMemo(
-    () => timeline.filter((event) => filter === "all" || event.event_type === filter),
+    () =>
+      timeline.filter(
+        (event) => filter === "all" || event.event_type === filter,
+      ),
     [timeline, filter],
   );
 
   const years = useMemo(
-    () => Array.from(new Set(filteredEvents.map((event) => new Date(event.occurred_at).getFullYear()))).sort((a, b) => a - b),
+    () =>
+      Array.from(
+        new Set(
+          filteredEvents.map((event) =>
+            new Date(event.occurred_at).getFullYear(),
+          ),
+        ),
+      ).sort((a, b) => a - b),
     [filteredEvents],
   );
 
-  const activeEvent = filteredEvents.find((event) => event.event_id === activeId) || null;
+  const groupedEvents = useMemo(() => {
+    const groups = [];
+    filteredEvents.forEach((event) => {
+      const date = new Date(event.occurred_at);
+      const monthKey = format(date, "yyyy-MM");
+      let month = groups.find((group) => group.key === monthKey);
+      if (!month) {
+        month = {
+          key: monthKey,
+          label: format(date, "MMMM yyyy"),
+          year: date.getFullYear(),
+          events: [],
+        };
+        groups.push(month);
+      }
+      month.events.push(event);
+    });
+    return groups;
+  }, [filteredEvents]);
+
+  const activeEvent = filteredEvents.find(
+    (event) => event.event_id === activeId,
+  );
   const teamName = space?.name ? `${space.name} team` : "The team";
 
   useEffect(() => {
@@ -265,10 +380,16 @@ export default function SpaceTimelinePage() {
     if (!rail) return undefined;
 
     const handleWheel = (event) => {
-      if (Math.abs(event.deltaY) <= Math.abs(event.deltaX) || Math.abs(event.deltaY) < 2) return;
+      if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
+      if (Math.abs(event.deltaY) < 2) return;
+
       const atStart = rail.scrollLeft <= 0 && event.deltaY < 0;
-      const atEnd = rail.scrollLeft + rail.clientWidth >= rail.scrollWidth - 1 && event.deltaY > 0;
+      const atEnd =
+        rail.scrollLeft + rail.clientWidth >= rail.scrollWidth - 1 &&
+        event.deltaY > 0;
+
       if (atStart || atEnd) return;
+
       event.preventDefault();
       rail.scrollLeft += event.deltaY;
     };
@@ -278,11 +399,30 @@ export default function SpaceTimelinePage() {
   }, []);
 
   const jump = (direction) => {
-    railRef.current?.scrollBy({ left: direction * Math.max(window.innerWidth * 0.72, 460), behavior: "smooth" });
+    railRef.current?.scrollBy({
+      left: direction * Math.max(window.innerWidth * 0.72, 460),
+      behavior: "smooth",
+    });
+  };
+
+  const jumpToYear = (year) => {
+    railRef.current
+      ?.querySelector(`[data-year="${year}"]`)
+      ?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+  };
+
+  const jumpToMonth = (monthKey) => {
+    railRef.current
+      ?.querySelector(`[data-month="${monthKey}"]`)
+      ?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
   };
 
   if (isLoading || timelineLoading) {
-    return <div className="min-h-dvh bg-background"><PageHeaderSkeleton /></div>;
+    return (
+      <div className="min-h-dvh bg-background">
+        <PageHeaderSkeleton />
+      </div>
+    );
   }
 
   if (error || !space) {
@@ -290,7 +430,9 @@ export default function SpaceTimelinePage() {
       <div className="flex min-h-dvh items-center justify-center bg-background px-6 text-center">
         <div>
           <h1 className="text-2xl font-semibold">Space not found</h1>
-          <p className="mt-2 text-muted-foreground">The requested Space does not exist.</p>
+          <p className="mt-2 text-muted-foreground">
+            The requested Space does not exist.
+          </p>
         </div>
       </div>
     );
@@ -299,9 +441,24 @@ export default function SpaceTimelinePage() {
   return (
     <div className="relative min-h-dvh overflow-hidden bg-background">
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <motion.div animate={{ x: [-80, 80, -80], y: [20, -30, 20] }} transition={{ duration: 22, repeat: Infinity, ease: "easeInOut" }} className="absolute left-[-10%] top-[-5%] h-[520px] w-[520px] rounded-full bg-primary/10 blur-[130px]" />
-        <motion.div animate={{ x: [70, -70, 70], y: [0, 50, 0] }} transition={{ duration: 26, repeat: Infinity, ease: "easeInOut" }} className="absolute bottom-[-10%] right-[-8%] h-[480px] w-[480px] rounded-full bg-primary/5 blur-[130px]" />
-        <div className="absolute inset-0 opacity-[0.025]" style={{ backgroundImage: `linear-gradient(to right, hsl(var(--foreground)) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--foreground)) 1px, transparent 1px)`, backgroundSize: "64px 64px" }} />
+        <motion.div
+          animate={{ x: [-80, 80, -80], y: [20, -30, 20] }}
+          transition={{ duration: 22, repeat: Infinity, ease: "easeInOut" }}
+          className="absolute left-[-10%] top-[-5%] h-[520px] w-[520px] rounded-full bg-primary/10 blur-[130px]"
+        />
+        <motion.div
+          animate={{ x: [70, -70, 70], y: [0, 50, 0] }}
+          transition={{ duration: 26, repeat: Infinity, ease: "easeInOut" }}
+          className="absolute bottom-[-10%] right-[-8%] h-[480px] w-[480px] rounded-full bg-primary/5 blur-[130px]"
+        />
+        <div
+          className="absolute inset-0 opacity-[0.025]"
+          style={{
+            backgroundImage:
+              "linear-gradient(to right, hsl(var(--foreground)) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--foreground)) 1px, transparent 1px)",
+            backgroundSize: "64px 64px",
+          }}
+        />
       </div>
 
       <div className="relative z-10 flex min-h-dvh flex-col">
@@ -311,31 +468,93 @@ export default function SpaceTimelinePage() {
             <div className="truncate text-sm font-medium">{space.name}</div>
             <div className="text-xs text-muted-foreground">The story so far</div>
           </div>
-          <Button variant="ghost" asChild className="rounded-full"><Link href={`/space/${space.slug}`}>Back to {space.name}</Link></Button>
+          <Button variant="ghost" asChild className="rounded-full">
+            <Link href={`/space/${space.slug}`}>Back to {space.name}</Link>
+          </Button>
         </header>
 
         <main className="flex min-h-0 flex-1 flex-col">
           <section className="mx-auto w-full max-w-7xl px-5 pb-8 pt-10 sm:px-8 sm:pt-16 lg:px-12">
             <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
               <div className="max-w-4xl">
-                <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground"><History className="h-3.5 w-3.5" />The story so far</div>
-                <h1 className="mt-4 text-5xl font-semibold tracking-tight sm:text-7xl lg:text-8xl">{space.name}</h1>
-                <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">A visual record of the people, places and moments that shaped the {space.name} team.</p>
+                <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                  <History className="h-3.5 w-3.5" />
+                  The story so far
+                </div>
+                <h1 className="mt-4 text-5xl font-semibold tracking-tight sm:text-7xl lg:text-8xl">
+                  {space.name}
+                </h1>
+                <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
+                  A visual record of the people, places and moments that shaped the {space.name} team.
+                </p>
               </div>
-              <div className="flex shrink-0 items-center gap-2"><Button variant="outline" size="icon" className="rounded-full" onClick={() => jump(-1)}><ArrowLeft className="h-4 w-4" /></Button><Button variant="outline" size="icon" className="rounded-full" onClick={() => jump(1)}><ArrowRight className="h-4 w-4" /></Button></div>
+
+              <div className="flex shrink-0 items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="rounded-full"
+                  onClick={() => jump(-1)}
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="rounded-full"
+                  onClick={() => jump(1)}
+                >
+                  <ArrowRight className="h-4 w-4" />
+                </Button>
+              </div>
             </div>
 
             <div className="mt-8 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div className="flex items-center gap-2 overflow-x-auto pb-1">
                 {years.map((year) => (
-                  <button key={year} type="button" onClick={() => railRef.current?.querySelector(`[data-year="${year}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" })} className="rounded-full border border-border bg-background/70 px-4 py-2 text-xs font-medium text-muted-foreground transition hover:border-foreground/20 hover:text-foreground">{year}</button>
+                  <button
+                    key={year}
+                    type="button"
+                    onClick={() => jumpToYear(year)}
+                    className="rounded-full border border-border bg-background/70 px-4 py-2 text-xs font-medium text-muted-foreground transition hover:border-foreground/20 hover:text-foreground"
+                  >
+                    {year}
+                  </button>
                 ))}
               </div>
 
               <div className="flex items-center gap-2 overflow-x-auto pb-1 lg:justify-end">
-                {["all", "member_joined", "report", "meeting", "event", "action", "announcement"].map((value) => (
-                  <button key={value} type="button" onClick={() => setFilter(value)} className={`shrink-0 rounded-full px-4 py-2 text-xs font-medium transition ${filter === value ? "bg-foreground text-background" : "bg-muted text-muted-foreground hover:text-foreground"}`}>
-                    {value === "all" ? "Everything" : value === "member_joined" ? "People" : value === "announcement" ? "Updates" : value === "report" ? "Reports" : `${value.charAt(0).toUpperCase()}${value.slice(1)}s`}
+                {[
+                  "all",
+                  "member_joined",
+                  "report",
+                  "meeting",
+                  "event",
+                  "action",
+                  "announcement",
+                ].map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => {
+                      setFilter(value);
+                      setActiveId(null);
+                    }}
+                    className={`shrink-0 rounded-full px-4 py-2 text-xs font-medium transition ${
+                      filter === value
+                        ? "bg-foreground text-background"
+                        : "bg-muted text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    {value === "all"
+                      ? "Everything"
+                      : value === "member_joined"
+                        ? "People"
+                        : value === "announcement"
+                          ? "Updates"
+                          : value === "report"
+                            ? "Reports"
+                            : `${value.charAt(0).toUpperCase()}${value.slice(1)}s`}
                   </button>
                 ))}
               </div>
@@ -343,45 +562,143 @@ export default function SpaceTimelinePage() {
           </section>
 
           <section className="relative flex-1 pb-12">
-            <div ref={railRef} className="scrollbar-hide flex h-[58vh] min-h-[430px] snap-x items-center gap-8 overflow-x-auto overflow-y-hidden px-[8vw] py-10">
-              {filteredEvents.map((event, index) => {
-                const image = getImage(event);
-                const year = new Date(event.occurred_at).getFullYear();
-                const selected = activeId === event.event_id;
-                const governanceCopy = governanceSentence(event, teamName);
-                return (
-                  <motion.button key={event.event_id} type="button" data-year={year} onClick={() => setActiveId((current) => (current === event.event_id ? null : event.event_id))} className="group relative h-[360px] w-[280px] shrink-0 snap-center overflow-hidden rounded-[30px] border border-border/70 bg-muted text-left shadow-sm transition focus:outline-none focus:ring-2 focus:ring-primary sm:h-[390px] sm:w-[310px] lg:w-[330px]" initial={{ opacity: 0, y: 24 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true, amount: 0.2 }} transition={{ duration: 0.5, delay: Math.min(index * 0.025, 0.18) }}>
-                    {image ? <img src={image} alt="" className="absolute inset-0 h-full w-full object-cover transition duration-700 ease-out group-hover:scale-[1.035]" /> : <div className="absolute inset-0 bg-gradient-to-br from-muted via-background to-muted-foreground/10" />}
-                    <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/5 to-transparent opacity-80 transition duration-500 group-hover:from-black/70" />
-                    <div className="absolute left-5 top-5 rounded-full bg-black/35 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.16em] text-white backdrop-blur">{format(new Date(event.occurred_at), "yyyy")}</div>
+            <div className="pointer-events-none absolute inset-x-0 top-1/2 hidden h-px bg-border/40 lg:block" />
 
-                    {event.event_type === "member_joined" && event.actor_name ? (
-                      <div className="absolute right-5 top-5 flex items-center gap-2 rounded-full bg-black/35 px-2 py-1.5 text-white backdrop-blur">
-                        <Avatar className="h-7 w-7 border border-white/25"><AvatarImage src={event.actor_avatar} alt={event.actor_name} /><AvatarFallback>{event.actor_name.charAt(0).toUpperCase()}</AvatarFallback></Avatar>
-                        <span className="max-w-24 truncate text-[10px] font-medium">{event.actor_name}</span>
+            <div
+              ref={railRef}
+              className="scrollbar-hide relative flex h-[64vh] min-h-[520px] snap-x items-center gap-12 overflow-x-auto overflow-y-hidden px-[8vw] py-10"
+            >
+              {groupedEvents.map((month, monthIndex) => (
+                <div
+                  key={month.key}
+                  data-month={month.key}
+                  data-year={month.year}
+                  className="relative flex h-full shrink-0 items-center"
+                >
+                  <div className="relative flex h-full w-[390px] flex-col justify-between sm:w-[440px] lg:w-[480px]">
+                    <div className="flex items-center gap-3 pb-3">
+                      <div className="h-2.5 w-2.5 rounded-full bg-foreground shadow-[0_0_0_7px_hsl(var(--background))]" />
+                      <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                        {month.label}
                       </div>
-                    ) : safeArray(event.governance_entities).length ? (
-                      <div className="absolute right-5 top-5 flex -space-x-1.5">{safeArray(event.governance_entities).slice(0, 3).map((item) => item.image_url ? <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" /> : <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">{(item.short_name || item.label || "G").charAt(0)}</div>)}</div>
-                    ) : null}
-
-                    <div className="absolute inset-x-5 bottom-5 text-white transition duration-300 group-hover:translate-y-[-4px]">
-                      <div className="text-xs font-medium uppercase tracking-[0.16em] text-white/70">{pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}</div>
-                      <div className="mt-2 line-clamp-2 text-xl font-semibold leading-tight">{event.title}</div>
-                      <div className="mt-2 max-h-0 overflow-hidden text-sm leading-6 text-white/75 opacity-0 transition-all duration-300 group-hover:max-h-20 group-hover:opacity-100">{event.description || naturalLabel(event)}</div>
-                      {governanceCopy ? <div className="mt-2 max-h-0 overflow-hidden text-xs leading-5 text-white/65 opacity-0 transition-all duration-300 group-hover:max-h-16 group-hover:opacity-100">{governanceCopy}</div> : null}
-                      {event.event_type === "member_joined" ? <MemberIdentity event={event} light /> : null}
                     </div>
 
-                    {selected ? <div className="absolute right-5 bottom-5 rounded-full bg-white px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-black shadow-lg">Selected</div> : null}
-                  </motion.button>
-                );
-              })}
+                    <div className="absolute bottom-1/2 left-0 top-1/2 hidden w-px -translate-x-1/2 bg-border lg:block" />
+
+                    <div className="grid h-[calc(100%-36px)] grid-rows-2 gap-7">
+                      {month.events.map((event, eventIndex) => {
+                        const isTop = (monthIndex + eventIndex) % 2 === 0;
+                        const imageAttachments = safeArray(event.attachments).filter((item) =>
+                          item?.mime_type?.startsWith("image/"),
+                        );
+                        const governance = safeArray(event.governance_entities);
+                        const selected = activeId === event.event_id;
+
+                        return (
+                          <div
+                            key={event.event_id}
+                            className={`flex ${
+                              isTop ? "items-end pb-3" : "items-start pt-3"
+                            } ${eventIndex % 2 === 1 ? "justify-end" : "justify-start"}`}
+                          >
+                            <motion.button
+                              type="button"
+                              onClick={() => {
+                                setActiveId(event.event_id);
+                                setSelectedEvent(event);
+                              }}
+                              className={`group relative h-[220px] w-[300px] overflow-hidden rounded-[30px] border border-border/70 bg-muted text-left shadow-sm transition focus:outline-none focus:ring-2 focus:ring-primary sm:h-[230px] sm:w-[330px] ${
+                                selected ? "ring-2 ring-primary/50" : ""
+                              }`}
+                              initial={{ opacity: 0, y: isTop ? 18 : -18 }}
+                              whileInView={{ opacity: 1, y: 0 }}
+                              viewport={{ once: true, amount: 0.2 }}
+                              transition={{ duration: 0.45, delay: Math.min(eventIndex * 0.04, 0.16) }}
+                            >
+                              {imageAttachments.length ? (
+                                <AutoImageCarousel attachments={imageAttachments} />
+                              ) : (
+                                <div className="absolute inset-0 bg-gradient-to-br from-muted via-background to-muted-foreground/10" />
+                              )}
+
+                              <div className="absolute inset-0 bg-gradient-to-t from-black/65 via-black/10 to-transparent" />
+
+                              <div className="absolute left-4 top-4 rounded-full bg-black/35 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.16em] text-white backdrop-blur">
+                                {format(new Date(event.occurred_at), "d MMM")}
+                              </div>
+
+                              {event.event_type === "member_joined" && event.actor_avatar ? (
+                                <Avatar className="absolute right-4 top-4 h-9 w-9 border-2 border-white/80 shadow-lg">
+                                  <AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} />
+                                  <AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback>
+                                </Avatar>
+                              ) : null}
+
+                              {governance.length ? (
+                                <div className="absolute right-4 top-4 flex -space-x-1.5">
+                                  {governance.slice(0, 3).map((item) =>
+                                    item.image_url ? (
+                                      <img
+                                        key={item.id}
+                                        src={item.image_url}
+                                        alt=""
+                                        className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain"
+                                      />
+                                    ) : (
+                                      <div
+                                        key={item.id}
+                                        className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground"
+                                      >
+                                        {(item.short_name || item.label || "G").charAt(0)}
+                                      </div>
+                                    ),
+                                  )}
+                                </div>
+                              ) : null}
+
+                              <div className="absolute inset-x-5 bottom-5 text-white transition duration-300 group-hover:-translate-y-1">
+                                <div className="text-xs font-medium uppercase tracking-[0.16em] text-white/70">
+                                  {pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}
+                                </div>
+                                <div className="mt-2 line-clamp-2 text-lg font-semibold leading-tight">
+                                  {event.title}
+                                </div>
+                                <div className="mt-2 max-h-0 overflow-hidden text-sm leading-5 text-white/75 opacity-0 transition-all duration-300 group-hover:max-h-16 group-hover:opacity-100">
+                                  {event.description || naturalLabel(event)}
+                                </div>
+                              </div>
+                            </motion.button>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {monthIndex < groupedEvents.length - 1 ? (
+                    <div className="ml-10 h-full w-px bg-border/30" />
+                  ) : null}
+                </div>
+              ))}
             </div>
-            <div className="pointer-events-none absolute left-[8vw] right-[8vw] top-1/2 hidden h-px -translate-y-1/2 bg-border/70 lg:block" />
-            <AnimatePresence>{activeEvent ? <EventDetail key={activeEvent.event_id} event={activeEvent} teamName={teamName} /> : null}</AnimatePresence>
           </section>
         </main>
       </div>
+
+      <AnimatePresence>
+        {selectedEvent ? (
+          <EventDialog
+            event={selectedEvent}
+            teamName={teamName}
+            open={!!selectedEvent}
+            onOpenChange={(open) => {
+              if (!open) {
+                setSelectedEvent(null);
+                setActiveId(null);
+              }
+            }}
+          />
+        ) : null}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/pages/space/[space]/timeline.js
+++ b/src/pages/space/[space]/timeline.js
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useRouter } from "next/router";
 import { motion } from "framer-motion";
 import { ArrowLeft, ArrowRight, ArrowUpRight, History } from "lucide-react";
 import { format } from "date-fns";
@@ -23,62 +22,14 @@ import PageHeaderSkeleton from "@/components/skeletons/PageHeaderSkeleton";
 import AutoImageCarousel from "@/components/attachment/AutoImageCarousel";
 
 const NATURAL_TEXT = {
-  space_created: [
-    "This is where the story began",
-    "This is where the work started",
-    "The first page of the story",
-    "The beginning of something local",
-    "This is where it all came together",
-  ],
-  member_joined: [
-    "Someone new joined the team",
-    "Another person came on board",
-    "The team grew a little stronger",
-    "A new contributor joined in",
-    "Another pair of hands joined the effort",
-  ],
-  report: [
-    "A piece of work took shape",
-    "The team moved an idea forward",
-    "Something useful came together",
-    "The team put its findings on record",
-    "The work turned into something concrete",
-  ],
-  meeting: [
-    "The team sat down to work through it",
-    "People came together to figure it out",
-    "A conversation moved the work forward",
-    "The right people got around the table",
-    "The team made time to work through the details",
-  ],
-  event: [
-    "The team showed up",
-    "The team stepped into the wider conversation",
-    "The work met the real world",
-    "The team took part in the moment",
-    "The team was there for it",
-  ],
-  action: [
-    "Something was done",
-    "The team moved from words to action",
-    "A small step became a real action",
-    "The team followed through",
-    "The work moved into the real world",
-  ],
-  announcement: [
-    "Something important was shared",
-    "The team had an update to share",
-    "A new chapter was announced",
-    "The team shared where things stood",
-    "A useful update made its way out",
-  ],
-  post: [
-    "A moment worth keeping",
-    "Something the team wanted on record",
-    "Another piece of the story",
-    "A moment from along the way",
-    "One more chapter in the journey",
-  ],
+  space_created: ["This is where the story began", "This is where the work started", "The first page of the story", "The beginning of something local", "This is where it all came together"],
+  member_joined: ["Someone new joined the team", "Another person came on board", "The team grew a little stronger", "A new contributor joined in", "Another pair of hands joined the effort"],
+  report: ["A piece of work took shape", "The team moved an idea forward", "Something useful came together", "The team put its findings on record", "The work turned into something concrete"],
+  meeting: ["The team sat down to work through it", "People came together to figure it out", "A conversation moved the work forward", "The right people got around the table", "The team made time to work through the details"],
+  event: ["The team showed up", "The team stepped into the wider conversation", "The work met the real world", "The team took part in the moment", "The team was there for it"],
+  action: ["Something was done", "The team moved from words to action", "A small step became a real action", "The team followed through", "The work moved into the real world"],
+  announcement: ["Something important was shared", "The team had an update to share", "A new chapter was announced", "The team shared where things stood", "A useful update made its way out"],
+  post: ["A moment worth keeping", "Something the team wanted on record", "Another piece of the story", "A moment from along the way", "One more chapter in the journey"],
 };
 
 const GOVERNANCE_TEXT = {
@@ -89,59 +40,46 @@ const GOVERNANCE_TEXT = {
   person: ["with", "alongside", "in conversation with"],
 };
 
-function safeArray(value) {
-  return Array.isArray(value) ? value : [];
-}
+const TIMELINE_PALETTE = [
+  { base: "#2563eb", soft: "#dbeafe" },
+  { base: "#16a34a", soft: "#dcfce7" },
+  { base: "#d97706", soft: "#fef3c7" },
+  { base: "#7c3aed", soft: "#ede9fe" },
+  { base: "#db2777", soft: "#fce7f3" },
+];
+
+function safeArray(value) { return Array.isArray(value) ? value : []; }
 
 function pickVariant(event, items) {
   const key = String(event.event_id || event.post_id || event.title || "timeline");
   let hash = 0;
-
-  for (let index = 0; index < key.length; index += 1) {
-    hash = (hash * 31 + key.charCodeAt(index)) >>> 0;
-  }
-
+  for (let index = 0; index < key.length; index += 1) hash = (hash * 31 + key.charCodeAt(index)) >>> 0;
   return items[hash % items.length];
 }
 
+function paletteFor(index) { return TIMELINE_PALETTE[index % TIMELINE_PALETTE.length]; }
+
 function naturalLabel(event) {
-  const title = event.title || "this moment";
-  return `${pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}: ${title}.`;
+  return `${pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}: ${event.title || "this moment"}.`;
 }
 
 function governanceSentence(event, teamName) {
   const governance = safeArray(event.governance_entities);
   if (!governance.length) return null;
-
   const item = governance[0];
   const name = item.short_name || item.label || "an authority";
   const type = item.entity_type || "authority";
   const phrase = pickVariant(event, GOVERNANCE_TEXT[type] || GOVERNANCE_TEXT.authority);
   const relationship = String(item.relationship_type || "").toLowerCase();
   const actor = teamName || "The team";
-
-  if (
-    relationship.includes("respons") ||
-    relationship.includes("owner") ||
-    relationship.includes("jurisdiction")
-  ) {
-    return `${actor} worked under ${name}.`;
-  }
-
-  if (relationship.includes("collabor") || relationship.includes("partner")) {
-    return `${actor} worked alongside ${name}.`;
-  }
-
-  if (relationship.includes("engag")) {
-    return `${actor} was in conversation with ${name}.`;
-  }
-
+  if (relationship.includes("respons") || relationship.includes("owner") || relationship.includes("jurisdiction")) return `${actor} worked under ${name}.`;
+  if (relationship.includes("collabor") || relationship.includes("partner")) return `${actor} worked alongside ${name}.`;
+  if (relationship.includes("engag")) return `${actor} was in conversation with ${name}.`;
   return `${actor} worked ${phrase} ${name}.`;
 }
 
 function MemberIdentity({ event, light = false }) {
   if (event.event_type !== "member_joined") return null;
-
   return (
     <div className={`flex items-center gap-2 ${light ? "text-white/85" : "text-foreground"}`}>
       <Avatar className={`h-9 w-9 border ${light ? "border-white/20" : "border-border"}`}>
@@ -159,16 +97,11 @@ function MemberIdentity({ event, light = false }) {
 function GovernanceRow({ event, light = false }) {
   const governance = safeArray(event.governance_entities);
   if (!governance.length) return null;
-
   return (
     <div className={`flex flex-wrap items-center gap-2 ${light ? "text-white/80" : "text-muted-foreground"}`}>
       {governance.slice(0, 4).map((item) => (
         <div key={item.id} className={`flex items-center gap-2 rounded-full border px-2.5 py-1.5 backdrop-blur ${light ? "border-white/15 bg-white/5" : "border-border bg-background/70"}`}>
-          {item.image_url ? (
-            <img src={item.image_url} alt="" className="h-5 w-5 rounded-full object-contain" />
-          ) : (
-            <div className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[9px] font-semibold">{(item.short_name || item.label || "G").charAt(0)}</div>
-          )}
+          {item.image_url ? <img src={item.image_url} alt="" className="h-5 w-5 rounded-full object-contain" /> : <div className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[9px] font-semibold">{(item.short_name || item.label || "G").charAt(0)}</div>}
           <span className="max-w-32 truncate text-[11px] font-medium">{item.short_name || item.label}</span>
         </div>
       ))}
@@ -178,19 +111,16 @@ function GovernanceRow({ event, light = false }) {
 
 function LinkList({ links = [] }) {
   if (!links.length) return null;
-
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-col gap-3">
       {links.slice(0, 4).map((link) => (
-        <a
-          key={link.id}
-          href={link.url}
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex max-w-full items-center gap-1.5 rounded-full border bg-background px-3 py-2 text-xs font-medium transition hover:bg-muted"
-        >
-          <span className="max-w-[320px] truncate sm:max-w-[480px]">{link.url}</span>
-          <ArrowUpRight className="h-3.5 w-3.5 shrink-0" />
+        <a key={link.id} href={link.url} target="_blank" rel="noreferrer" className="group flex items-center gap-3 rounded-2xl border bg-background p-3 transition hover:bg-muted/60">
+          {link.image_url ? <img src={link.image_url} alt="" className="h-16 w-24 shrink-0 rounded-xl object-cover" /> : <div className="flex h-16 w-24 shrink-0 items-center justify-center rounded-xl bg-muted text-xs text-muted-foreground">Link</div>}
+          <div className="min-w-0 flex-1">
+            <div className="line-clamp-2 text-sm font-medium leading-5">{link.title || link.hostname || link.url}</div>
+            <div className="mt-1 truncate text-xs text-muted-foreground">{link.url}</div>
+          </div>
+          <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground transition group-hover:text-foreground" />
         </a>
       ))}
     </div>
@@ -201,7 +131,6 @@ function EventDialog({ event, teamName, open, onOpenChange }) {
   const imageAttachments = safeArray(event.attachments).filter((item) => item?.mime_type?.startsWith("image/"));
   const links = safeArray(event.links);
   const governanceCopy = governanceSentence(event, teamName);
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[88vh] max-w-4xl overflow-y-auto rounded-[30px] border bg-background p-0">
@@ -216,26 +145,10 @@ function EventDialog({ event, teamName, open, onOpenChange }) {
               </div>
             </div>
           ) : null}
-
           <div className="space-y-5 p-6 sm:p-8">
-            {!imageAttachments.length ? (
-              <div>
-                <div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{format(new Date(event.occurred_at), "d MMMM yyyy")}</div>
-                <DialogTitle className="mt-2 text-3xl font-semibold tracking-tight sm:text-4xl">{event.title}</DialogTitle>
-              </div>
-            ) : null}
-
+            {!imageAttachments.length ? <div><div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{format(new Date(event.occurred_at), "d MMMM yyyy")}</div><DialogTitle className="mt-2 text-3xl font-semibold tracking-tight sm:text-4xl">{event.title}</DialogTitle></div> : null}
             <DialogDescription className="text-base leading-7 text-muted-foreground">{event.description || naturalLabel(event)}</DialogDescription>
-
-            {event.event_type === "member_joined" ? (
-              <MemberIdentity event={event} />
-            ) : event.actor_name ? (
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Avatar className="h-8 w-8 border"><AvatarImage src={event.actor_avatar} alt={event.actor_name} /><AvatarFallback>{event.actor_name.charAt(0).toUpperCase()}</AvatarFallback></Avatar>
-                <span>{event.actor_name}</span>
-              </div>
-            ) : null}
-
+            {event.event_type === "member_joined" ? <MemberIdentity event={event} /> : event.actor_name ? <div className="flex items-center gap-2 text-sm text-muted-foreground"><Avatar className="h-8 w-8 border"><AvatarImage src={event.actor_avatar} alt={event.actor_name} /><AvatarFallback>{event.actor_name.charAt(0).toUpperCase()}</AvatarFallback></Avatar><span>{event.actor_name}</span></div> : null}
             {governanceCopy ? <p className="text-sm leading-6 text-muted-foreground">{governanceCopy}</p> : null}
             <GovernanceRow event={event} />
             {event.address ? <div className="rounded-2xl border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">{event.address}</div> : null}
@@ -251,23 +164,14 @@ export default function SpaceTimelinePage() {
   const router = useRouter();
   const railRef = useRef(null);
   const { space: slug } = router.query;
-
   const { data: space, isLoading, error } = useSpaces({ slug, enabled: !!slug });
   const { data: timeline = [], isLoading: timelineLoading } = useSpaceTimeline(space?.id);
-
   const [filter, setFilter] = useState("all");
   const [selectedEvent, setSelectedEvent] = useState(null);
+  const [focusIndex, setFocusIndex] = useState(0);
 
-  const filteredEvents = useMemo(
-    () => timeline.filter((event) => filter === "all" || event.event_type === filter),
-    [timeline, filter],
-  );
-
-  const years = useMemo(
-    () => Array.from(new Set(filteredEvents.map((event) => new Date(event.occurred_at).getFullYear()))).sort((a, b) => a - b),
-    [filteredEvents],
-  );
-
+  const filteredEvents = useMemo(() => timeline.filter((event) => filter === "all" || event.event_type === filter), [timeline, filter]);
+  const years = useMemo(() => Array.from(new Set(filteredEvents.map((event) => new Date(event.occurred_at).getFullYear()))).sort((a, b) => a - b), [filteredEvents]);
   const monthMarkers = useMemo(() => {
     const seen = new Set();
     return filteredEvents.reduce((markers, event, index) => {
@@ -275,22 +179,38 @@ export default function SpaceTimelinePage() {
       const key = format(date, "yyyy-MM");
       if (seen.has(key)) return markers;
       seen.add(key);
-      markers.push({
-        key,
-        label: format(date, "MMM yyyy"),
-        year: date.getFullYear(),
-        index,
-      });
+      markers.push({ key, label: format(date, "MMM yyyy"), year: date.getFullYear(), index });
       return markers;
     }, []);
   }, [filteredEvents]);
-
   const teamName = space?.name ? `${space.name} team` : "The team";
 
   useEffect(() => {
     const rail = railRef.current;
     if (!rail) return undefined;
+    const handleScroll = () => {
+      const cards = Array.from(rail.querySelectorAll("[data-event-index]"));
+      if (!cards.length) return;
+      const center = rail.scrollLeft + rail.clientWidth / 2;
+      let nearest = 0;
+      let distance = Number.POSITIVE_INFINITY;
+      cards.forEach((card, index) => {
+        const rect = card.getBoundingClientRect();
+        const railRect = rail.getBoundingClientRect();
+        const cardCenter = rect.left - railRect.left + rail.scrollLeft + rect.width / 2;
+        const nextDistance = Math.abs(cardCenter - center);
+        if (nextDistance < distance) { distance = nextDistance; nearest = Number(card.dataset.eventIndex ?? index); }
+      });
+      setFocusIndex(nearest);
+    };
+    handleScroll();
+    rail.addEventListener("scroll", handleScroll, { passive: true });
+    return () => rail.removeEventListener("scroll", handleScroll);
+  }, [filteredEvents.length]);
 
+  useEffect(() => {
+    const rail = railRef.current;
+    if (!rail) return undefined;
     const handleWheel = (event) => {
       if (Math.abs(event.deltaY) <= Math.abs(event.deltaX) || Math.abs(event.deltaY) < 2) return;
       const atStart = rail.scrollLeft <= 0 && event.deltaY < 0;
@@ -299,37 +219,18 @@ export default function SpaceTimelinePage() {
       event.preventDefault();
       rail.scrollLeft += event.deltaY;
     };
-
     rail.addEventListener("wheel", handleWheel, { passive: false });
     return () => rail.removeEventListener("wheel", handleWheel);
   }, []);
 
-  const jump = (direction) => {
-    railRef.current?.scrollBy({ left: direction * Math.max(window.innerWidth * 0.72, 460), behavior: "smooth" });
-  };
+  const jump = (direction) => railRef.current?.scrollBy({ left: direction * Math.max(window.innerWidth * 0.72, 460), behavior: "smooth" });
+  const jumpToYear = (year) => railRef.current?.querySelector(`[data-year="${year}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+  const jumpToMonth = (monthKey) => railRef.current?.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
 
-  const jumpToYear = (year) => {
-    railRef.current?.querySelector(`[data-year="${year}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
-  };
+  if (isLoading || timelineLoading) return <div className="min-h-dvh bg-background"><PageHeaderSkeleton /></div>;
+  if (error || !space) return <div className="flex min-h-dvh items-center justify-center bg-background px-6 text-center"><div><h1 className="text-2xl font-semibold">Space not found</h1><p className="mt-2 text-muted-foreground">The requested Space does not exist.</p></div></div>;
 
-  const jumpToMonth = (monthKey) => {
-    railRef.current?.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
-  };
-
-  if (isLoading || timelineLoading) {
-    return <div className="min-h-dvh bg-background"><PageHeaderSkeleton /></div>;
-  }
-
-  if (error || !space) {
-    return (
-      <div className="flex min-h-dvh items-center justify-center bg-background px-6 text-center">
-        <div>
-          <h1 className="text-2xl font-semibold">Space not found</h1>
-          <p className="mt-2 text-muted-foreground">The requested Space does not exist.</p>
-        </div>
-      </div>
-    );
-  }
+  const focusedPalette = paletteFor(focusIndex);
 
   return (
     <div className="relative min-h-dvh overflow-hidden bg-background">
@@ -342,10 +243,7 @@ export default function SpaceTimelinePage() {
       <div className="relative z-10 flex min-h-dvh flex-col">
         <header className="flex items-center gap-3 border-b border-border/70 px-4 py-3 sm:px-6 lg:px-8">
           <BackButton />
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-sm font-medium">{space.name}</div>
-            <div className="text-xs text-muted-foreground">The story so far</div>
-          </div>
+          <div className="min-w-0 flex-1"><div className="truncate text-sm font-medium">{space.name}</div><div className="text-xs text-muted-foreground">The story so far</div></div>
           <Button variant="ghost" asChild className="rounded-full"><Link href={`/space/${space.slug}`}>Back to {space.name}</Link></Button>
         </header>
 
@@ -361,100 +259,46 @@ export default function SpaceTimelinePage() {
             </div>
 
             <div className="mt-8 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <div className="flex items-center gap-2 overflow-x-auto pb-1">
-                {years.map((year) => <button key={year} type="button" onClick={() => jumpToYear(year)} className="shrink-0 rounded-full border border-border bg-background/70 px-4 py-2 text-xs font-medium text-muted-foreground transition hover:border-foreground/20 hover:text-foreground">{year}</button>)}
-              </div>
-              <div className="flex items-center gap-2 overflow-x-auto pb-1 lg:justify-end">
-                {["all", "member_joined", "report", "meeting", "event", "action", "announcement"].map((value) => (
-                  <button key={value} type="button" onClick={() => setFilter(value)} className={`shrink-0 rounded-full px-4 py-2 text-xs font-medium transition ${filter === value ? "bg-foreground text-background" : "bg-muted text-muted-foreground hover:text-foreground"}`}>
-                    {value === "all" ? "Everything" : value === "member_joined" ? "People" : value === "announcement" ? "Updates" : value === "report" ? "Reports" : `${value.charAt(0).toUpperCase()}${value.slice(1)}s`}
-                  </button>
-                ))}
-              </div>
+              <div className="flex items-center gap-2 overflow-x-auto pb-1">{years.map((year) => <button key={year} type="button" onClick={() => jumpToYear(year)} className="shrink-0 rounded-full border border-border bg-background/70 px-4 py-2 text-xs font-medium text-muted-foreground transition hover:border-foreground/20 hover:text-foreground">{year}</button>)}</div>
+              <div className="flex items-center gap-2 overflow-x-auto pb-1 lg:justify-end">{["all", "member_joined", "report", "meeting", "event", "action", "announcement"].map((value) => <button key={value} type="button" onClick={() => setFilter(value)} className={`shrink-0 rounded-full px-4 py-2 text-xs font-medium transition ${filter === value ? "bg-foreground text-background" : "bg-muted text-muted-foreground hover:text-foreground"}`}>{value === "all" ? "Everything" : value === "member_joined" ? "People" : value === "announcement" ? "Updates" : value === "report" ? "Reports" : `${value.charAt(0).toUpperCase()}${value.slice(1)}s`}</button>)}</div>
             </div>
+
+            <div className="mt-6 flex items-center gap-2 overflow-x-auto pb-1">{monthMarkers.map((month, index) => { const palette = paletteFor(index); return <button key={month.key} type="button" onClick={() => jumpToMonth(month.key)} className="flex shrink-0 items-center gap-2 rounded-full border border-border bg-background/70 px-3 py-1.5 text-[11px] font-medium text-muted-foreground transition hover:text-foreground"><span className="h-2 w-2 rounded-full" style={{ backgroundColor: palette.base }} />{month.label}</button>; })}</div>
           </section>
 
           <section className="relative flex-1 pb-12">
-            <div ref={railRef} className="scrollbar-hide relative h-[64vh] min-h-[540px] overflow-x-auto overflow-y-hidden px-[7vw] py-8 sm:px-[8vw]">
-              <div className="relative flex h-full min-w-max items-center">
-                <div className="relative h-full min-w-max" style={{ width: `${Math.max(filteredEvents.length, 1) * 430}px` }}>
-                  <div className="absolute left-0 right-0 top-1/2 h-[5px] -translate-y-1/2 overflow-hidden rounded-full bg-muted">
-                    <motion.div
-                      className="absolute inset-y-0 left-0 w-[42%] rounded-full bg-gradient-to-r from-primary/20 via-primary/70 to-primary"
-                      animate={{ x: ["-10%", "165%"] }}
-                      transition={{ duration: 7, repeat: Infinity, ease: "easeInOut" }}
-                    />
-                  </div>
+            <div ref={railRef} className="scrollbar-hide relative h-[64vh] min-h-[500px] overflow-x-auto overflow-y-hidden px-[7vw] py-6 sm:px-[8vw]">
+              <div className="relative flex min-w-max items-center gap-12 py-20" style={{ minHeight: "100%" }}>
+                <div className="pointer-events-none absolute left-0 right-0 top-1/2 h-[3px] -translate-y-1/2 rounded-full bg-muted/80" />
+                <motion.div className="pointer-events-none absolute left-0 top-1/2 h-[4px] -translate-y-1/2 rounded-full" animate={{ backgroundColor: focusedPalette.base, width: `${((focusIndex + 1) / Math.max(filteredEvents.length, 1)) * 100}%` }} transition={{ duration: 0.7, ease: "easeOut" }} style={{ maxWidth: "100%" }} />
 
-                  <div className="absolute left-0 right-0 top-1/2 flex -translate-y-1/2 items-center">
-                    {monthMarkers.map((month, monthIndex) => {
-                      const position = month.index / Math.max(filteredEvents.length - 1, 1);
-                      return (
-                        <button
-                          key={month.key}
-                          type="button"
-                          data-month={month.key}
-                          data-year={month.year}
-                          onClick={() => jumpToMonth(month.key)}
-                          className="absolute top-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-2"
-                          style={{ left: `${position * 100}%` }}
-                        >
-                          <span className="h-4 w-4 rounded-full border-[3px] border-background bg-foreground shadow-[0_0_0_4px_hsl(var(--background))]" />
-                          <span className="whitespace-nowrap rounded-full border bg-background/95 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground shadow-sm backdrop-blur">
-                            {month.label}
-                          </span>
-                        </button>
-                      );
-                    })}
-                  </div>
+                {filteredEvents.map((event, index) => {
+                  const date = new Date(event.occurred_at);
+                  const monthKey = format(date, "yyyy-MM");
+                  const monthIndex = monthMarkers.findIndex((month) => month.key === monthKey);
+                  const palette = paletteFor(monthIndex >= 0 ? monthIndex : index);
+                  const above = index % 2 === 0;
+                  const imageAttachments = safeArray(event.attachments).filter((item) => item?.mime_type?.startsWith("image/"));
+                  const governance = safeArray(event.governance_entities);
+                  const governanceCopy = governanceSentence(event, teamName);
+                  const isFocused = index === focusIndex;
 
-                  {filteredEvents.map((event, index) => {
-                    const imageAttachments = safeArray(event.attachments).filter((item) => item?.mime_type?.startsWith("image/"));
-                    const governance = safeArray(event.governance_entities);
-                    const governanceCopy = governanceSentence(event, teamName);
-                    const above = index % 2 === 0;
-                    const left = `${(index + 0.5) * 430}px`;
+                  return (
+                    <div key={event.event_id} data-event-index={index} data-year={date.getFullYear()} data-month={monthKey} className="relative h-[560px] w-[360px] shrink-0 sm:w-[400px]">
+                      <div className="absolute left-1/2 top-1/2 z-0 h-px w-[72px] -translate-y-1/2" style={{ background: `linear-gradient(90deg, transparent, ${palette.base}99)` }} />
+                      <motion.div className="absolute left-1/2 z-0 w-[2px] -translate-x-1/2" animate={{ backgroundColor: isFocused ? palette.base : `${palette.base}77` }} transition={{ duration: 0.3 }} style={above ? { top: "calc(50% - 92px)", height: "92px" } : { top: "50%", height: "92px" }} />
 
-                    return (
-                      <motion.button
-                        key={event.event_id}
-                        type="button"
-                        data-event="true"
-                        onClick={() => setSelectedEvent(event)}
-                        className={`group absolute left-0 z-10 h-[230px] w-[360px] -translate-x-1/2 overflow-hidden rounded-[30px] border border-border/70 bg-muted text-left shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary sm:h-[250px] sm:w-[390px] ${above ? "bottom-[calc(50%+42px)]" : "top-[calc(50%+42px)]"}`}
-                        style={{ left }}
-                        initial={{ opacity: 0, y: above ? 20 : -20 }}
-                        whileInView={{ opacity: 1, y: 0 }}
-                        viewport={{ once: true, amount: 0.15 }}
-                        transition={{ duration: 0.45, delay: Math.min(index * 0.025, 0.16) }}
-                      >
+                      <motion.button type="button" onClick={() => setSelectedEvent(event)} className="group absolute left-1/2 z-10 h-[220px] w-[330px] -translate-x-1/2 overflow-hidden rounded-[30px] border border-border/70 bg-muted text-left transition duration-300 hover:-translate-y-1 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary sm:h-[240px] sm:w-[360px]" style={above ? { bottom: "50%", marginBottom: "22px" } : { top: "50%", marginTop: "22px" }} animate={isFocused ? { boxShadow: `0 0 0 2px ${palette.base}35, 0 16px 36px rgba(0,0,0,0.12)` } : { boxShadow: "0 4px 20px rgba(0,0,0,0.06)" }} initial={{ opacity: 0, y: above ? 16 : -16 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true, amount: 0.15 }} transition={{ duration: 0.45, delay: Math.min(index * 0.02, 0.16) }}>
                         {imageAttachments.length ? <AutoImageCarousel attachments={imageAttachments} /> : <div className="absolute inset-0 bg-gradient-to-br from-muted via-background to-muted-foreground/10" />}
-                        <div className="absolute inset-0 bg-gradient-to-t from-black/65 via-black/10 to-transparent transition duration-300 group-hover:from-black/80" />
-
-                        <div className="absolute left-4 top-4 rounded-full bg-black/35 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.16em] text-white backdrop-blur">{format(new Date(event.occurred_at), "d MMM")}</div>
-
-                        {governance.length ? (
-                          <div className="absolute right-4 top-4 flex -space-x-1.5">
-                            {governance.slice(0, 3).map((item) => item.image_url ? <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" /> : <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">{(item.short_name || item.label || "G").charAt(0)}</div>)}
-                          </div>
-                        ) : null}
-
-                        {event.event_type === "member_joined" ? (
-                          <div className="absolute left-4 bottom-20 flex items-center gap-2 rounded-full bg-black/35 px-2 py-1.5 text-white backdrop-blur">
-                            <Avatar className="h-7 w-7 border border-white/20"><AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} /><AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback></Avatar>
-                            <span className="max-w-[180px] truncate text-xs font-medium">{event.actor_name || "New member"}</span>
-                          </div>
-                        ) : null}
-
-                        <div className="absolute inset-x-4 bottom-4 text-white">
-                          <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/70">{pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}</div>
-                          <div className="mt-1 line-clamp-2 text-lg font-semibold leading-tight">{event.title}</div>
-                          {governanceCopy ? <div className="mt-1 line-clamp-1 text-xs text-white/60">{governanceCopy}</div> : null}
-                        </div>
+                        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/15 to-transparent" />
+                        <div className="absolute left-4 top-4 rounded-full px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.16em] text-white shadow-sm backdrop-blur" style={{ backgroundColor: `${palette.base}dd` }}>{format(date, "d MMM")}</div>
+                        {governance.length ? <div className="absolute right-4 top-4 flex -space-x-1.5">{governance.slice(0, 3).map((item) => item.image_url ? <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" /> : <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">{(item.short_name || item.label || "G").charAt(0)}</div>)}</div> : null}
+                        {event.event_type === "member_joined" ? <div className="absolute left-4 bottom-20 flex items-center gap-2 rounded-full bg-black/35 px-2 py-1.5 text-white backdrop-blur"><Avatar className="h-7 w-7 border border-white/20"><AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} /><AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback></Avatar><span className="max-w-[170px] truncate text-xs font-medium">{event.actor_name || "New member"}</span></div> : null}
+                        <div className="absolute inset-x-4 bottom-4 text-white"><div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/70">{pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}</div><div className="mt-1 line-clamp-2 text-lg font-semibold leading-tight">{event.title}</div>{governanceCopy ? <div className="mt-1 line-clamp-1 text-xs text-white/60">{governanceCopy}</div> : null}</div>
                       </motion.button>
-                    );
-                  })}
-                </div>
+                    </div>
+                  );
+                })}
               </div>
             </div>
           </section>

--- a/src/pages/space/[space]/timeline.js
+++ b/src/pages/space/[space]/timeline.js
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import { motion } from "framer-motion";
 import { ArrowLeft, ArrowRight, ArrowUpRight, History } from "lucide-react";
@@ -120,7 +120,11 @@ function governanceSentence(event, teamName) {
   const relationship = String(item.relationship_type || "").toLowerCase();
   const actor = teamName || "The team";
 
-  if (relationship.includes("respons") || relationship.includes("owner") || relationship.includes("jurisdiction")) {
+  if (
+    relationship.includes("respons") ||
+    relationship.includes("owner") ||
+    relationship.includes("jurisdiction")
+  ) {
     return `${actor} worked under ${name}.`;
   }
 
@@ -159,18 +163,11 @@ function GovernanceRow({ event, light = false }) {
   return (
     <div className={`flex flex-wrap items-center gap-2 ${light ? "text-white/80" : "text-muted-foreground"}`}>
       {governance.slice(0, 4).map((item) => (
-        <div
-          key={item.id}
-          className={`flex items-center gap-2 rounded-full border px-2.5 py-1.5 backdrop-blur ${
-            light ? "border-white/15 bg-white/5" : "border-border bg-background/70"
-          }`}
-        >
+        <div key={item.id} className={`flex items-center gap-2 rounded-full border px-2.5 py-1.5 backdrop-blur ${light ? "border-white/15 bg-white/5" : "border-border bg-background/70"}`}>
           {item.image_url ? (
             <img src={item.image_url} alt="" className="h-5 w-5 rounded-full object-contain" />
           ) : (
-            <div className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[9px] font-semibold">
-              {(item.short_name || item.label || "G").charAt(0)}
-            </div>
+            <div className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[9px] font-semibold">{(item.short_name || item.label || "G").charAt(0)}</div>
           )}
           <span className="max-w-32 truncate text-[11px] font-medium">{item.short_name || item.label}</span>
         </div>
@@ -179,25 +176,20 @@ function GovernanceRow({ event, light = false }) {
   );
 }
 
-function LinkList({ links, light = false }) {
+function LinkList({ links = [] }) {
   if (!links.length) return null;
 
   return (
-    <div className={`space-y-2 ${light ? "text-white/80" : "text-muted-foreground"}`}>
+    <div className="flex flex-wrap gap-2">
       {links.slice(0, 4).map((link) => (
         <a
           key={link.id}
           href={link.url}
           target="_blank"
           rel="noreferrer"
-          className={`flex items-center gap-2 rounded-xl border px-3 py-2 text-xs transition ${
-            light
-              ? "border-white/15 bg-white/5 hover:bg-white/10"
-              : "border-border bg-background hover:bg-muted"
-          }`}
-          onClick={(event) => event.stopPropagation()}
+          className="inline-flex max-w-full items-center gap-1.5 rounded-full border bg-background px-3 py-2 text-xs font-medium transition hover:bg-muted"
         >
-          <span className="min-w-0 flex-1 truncate">{link.url}</span>
+          <span className="max-w-[320px] truncate sm:max-w-[480px]">{link.url}</span>
           <ArrowUpRight className="h-3.5 w-3.5 shrink-0" />
         </a>
       ))}
@@ -239,10 +231,7 @@ function EventDialog({ event, teamName, open, onOpenChange }) {
               <MemberIdentity event={event} />
             ) : event.actor_name ? (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Avatar className="h-8 w-8 border">
-                  <AvatarImage src={event.actor_avatar} alt={event.actor_name} />
-                  <AvatarFallback>{event.actor_name.charAt(0).toUpperCase()}</AvatarFallback>
-                </Avatar>
+                <Avatar className="h-8 w-8 border"><AvatarImage src={event.actor_avatar} alt={event.actor_name} /><AvatarFallback>{event.actor_name.charAt(0).toUpperCase()}</AvatarFallback></Avatar>
                 <span>{event.actor_name}</span>
               </div>
             ) : null}
@@ -281,12 +270,17 @@ export default function SpaceTimelinePage() {
 
   const monthMarkers = useMemo(() => {
     const seen = new Set();
-    return filteredEvents.reduce((markers, event) => {
+    return filteredEvents.reduce((markers, event, index) => {
       const date = new Date(event.occurred_at);
       const key = format(date, "yyyy-MM");
       if (seen.has(key)) return markers;
       seen.add(key);
-      markers.push({ key, label: format(date, "MMM yyyy"), year: date.getFullYear() });
+      markers.push({
+        key,
+        label: format(date, "MMM yyyy"),
+        year: date.getFullYear(),
+        index,
+      });
       return markers;
     }, []);
   }, [filteredEvents]);
@@ -316,6 +310,10 @@ export default function SpaceTimelinePage() {
 
   const jumpToYear = (year) => {
     railRef.current?.querySelector(`[data-year="${year}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+  };
+
+  const jumpToMonth = (monthKey) => {
+    railRef.current?.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
   };
 
   if (isLoading || timelineLoading) {
@@ -377,99 +375,93 @@ export default function SpaceTimelinePage() {
           </section>
 
           <section className="relative flex-1 pb-12">
-            <div ref={railRef} className="scrollbar-hide flex h-[64vh] min-h-[500px] items-stretch gap-0 overflow-x-auto overflow-y-hidden px-[7vw] py-6 sm:px-[8vw]">
-              <div className="relative flex min-w-max items-center py-20">
-                <div className="absolute left-0 right-0 top-1/2 h-px bg-border/80" />
-
-                {monthMarkers.map((month, monthIndex) => (
-                  <div key={month.key} data-year={month.year} className="relative flex w-[24rem] shrink-0 flex-col items-center">
-                    <div className="absolute left-1/2 top-1/2 z-20 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-background bg-foreground shadow-[0_0_0_5px_hsl(var(--background))]" />
-                    <div className="absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded-full border bg-background/95 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground shadow-sm backdrop-blur">
-                      {month.label}
-                    </div>
-
-                    <div className="flex h-[580px] w-full flex-col items-center justify-between">
-                      {filteredEvents
-                        .filter((event) => format(new Date(event.occurred_at), "yyyy-MM") === month.key)
-                        .map((event, eventIndex) => {
-                          const imageAttachments = safeArray(event.attachments).filter((item) => item?.mime_type?.startsWith("image/"));
-                          const governance = safeArray(event.governance_entities);
-                          const governanceCopy = governanceSentence(event, teamName);
-                          const above = (eventIndex + monthIndex) % 2 === 0;
-
-                          return (
-                            <div key={event.event_id} className={`relative flex w-full justify-center ${above ? "items-end pb-8" : "items-start pt-8"} h-[48%]`}>
-                              <div className={`absolute left-1/2 w-px bg-border ${above ? "top-1/2 bottom-0" : "top-0 bottom-1/2"}`} />
-
-                              <motion.button
-                                type="button"
-                                onClick={() => setSelectedEvent(event)}
-                                className="group relative z-10 h-[220px] w-[330px] shrink-0 overflow-hidden rounded-[30px] border border-border/70 bg-muted text-left shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary sm:h-[240px] sm:w-[360px]"
-                                initial={{ opacity: 0, y: above ? 20 : -20 }}
-                                whileInView={{ opacity: 1, y: 0 }}
-                                viewport={{ once: true, amount: 0.2 }}
-                                transition={{ duration: 0.45, delay: Math.min(eventIndex * 0.04, 0.16) }}
-                              >
-                                {imageAttachments.length ? (
-                                  <AutoImageCarousel attachments={imageAttachments} />
-                                ) : (
-                                  <div className="absolute inset-0 bg-gradient-to-br from-muted via-background to-muted-foreground/10" />
-                                )}
-
-                                <div className="absolute inset-0 bg-gradient-to-t from-black/65 via-black/10 to-transparent transition duration-300 group-hover:from-black/80" />
-
-                                <div className="absolute left-4 top-4 rounded-full bg-black/35 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.16em] text-white backdrop-blur">
-                                  {format(new Date(event.occurred_at), "d MMM")}
-                                </div>
-
-                                {governance.length ? (
-                                  <div className="absolute right-4 top-4 flex -space-x-1.5">
-                                    {governance.slice(0, 3).map((item) => item.image_url ? (
-                                      <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" />
-                                    ) : (
-                                      <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">{(item.short_name || item.label || "G").charAt(0)}</div>
-                                    ))}
-                                  </div>
-                                ) : null}
-
-                                {event.event_type === "member_joined" ? (
-                                  <div className="absolute left-4 bottom-20 flex items-center gap-2 rounded-full bg-black/35 px-2 py-1.5 text-white backdrop-blur">
-                                    <Avatar className="h-7 w-7 border border-white/20">
-                                      <AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} />
-                                      <AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback>
-                                    </Avatar>
-                                    <span className="max-w-[170px] truncate text-xs font-medium">{event.actor_name || "New member"}</span>
-                                  </div>
-                                ) : null}
-
-                                <div className="absolute inset-x-4 bottom-4 text-white">
-                                  <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/70">{pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}</div>
-                                  <div className="mt-1 line-clamp-2 text-lg font-semibold leading-tight">{event.title}</div>
-                                  {governanceCopy ? <div className="mt-1 line-clamp-1 text-xs text-white/60">{governanceCopy}</div> : null}
-                                </div>
-                              </motion.button>
-                            </div>
-                          );
-                        })}
-                    </div>
+            <div ref={railRef} className="scrollbar-hide relative h-[64vh] min-h-[540px] overflow-x-auto overflow-y-hidden px-[7vw] py-8 sm:px-[8vw]">
+              <div className="relative flex h-full min-w-max items-center">
+                <div className="relative h-full min-w-max" style={{ width: `${Math.max(filteredEvents.length, 1) * 430}px` }}>
+                  <div className="absolute left-0 right-0 top-1/2 h-[5px] -translate-y-1/2 overflow-hidden rounded-full bg-muted">
+                    <motion.div
+                      className="absolute inset-y-0 left-0 w-[42%] rounded-full bg-gradient-to-r from-primary/20 via-primary/70 to-primary"
+                      animate={{ x: ["-10%", "165%"] }}
+                      transition={{ duration: 7, repeat: Infinity, ease: "easeInOut" }}
+                    />
                   </div>
-                ))}
+
+                  <div className="absolute left-0 right-0 top-1/2 flex -translate-y-1/2 items-center">
+                    {monthMarkers.map((month, monthIndex) => {
+                      const position = month.index / Math.max(filteredEvents.length - 1, 1);
+                      return (
+                        <button
+                          key={month.key}
+                          type="button"
+                          data-month={month.key}
+                          data-year={month.year}
+                          onClick={() => jumpToMonth(month.key)}
+                          className="absolute top-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-2"
+                          style={{ left: `${position * 100}%` }}
+                        >
+                          <span className="h-4 w-4 rounded-full border-[3px] border-background bg-foreground shadow-[0_0_0_4px_hsl(var(--background))]" />
+                          <span className="whitespace-nowrap rounded-full border bg-background/95 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground shadow-sm backdrop-blur">
+                            {month.label}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  {filteredEvents.map((event, index) => {
+                    const imageAttachments = safeArray(event.attachments).filter((item) => item?.mime_type?.startsWith("image/"));
+                    const governance = safeArray(event.governance_entities);
+                    const governanceCopy = governanceSentence(event, teamName);
+                    const above = index % 2 === 0;
+                    const left = `${(index + 0.5) * 430}px`;
+
+                    return (
+                      <motion.button
+                        key={event.event_id}
+                        type="button"
+                        data-event="true"
+                        onClick={() => setSelectedEvent(event)}
+                        className={`group absolute left-0 z-10 h-[230px] w-[360px] -translate-x-1/2 overflow-hidden rounded-[30px] border border-border/70 bg-muted text-left shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary sm:h-[250px] sm:w-[390px] ${above ? "bottom-[calc(50%+42px)]" : "top-[calc(50%+42px)]"}`}
+                        style={{ left }}
+                        initial={{ opacity: 0, y: above ? 20 : -20 }}
+                        whileInView={{ opacity: 1, y: 0 }}
+                        viewport={{ once: true, amount: 0.15 }}
+                        transition={{ duration: 0.45, delay: Math.min(index * 0.025, 0.16) }}
+                      >
+                        {imageAttachments.length ? <AutoImageCarousel attachments={imageAttachments} /> : <div className="absolute inset-0 bg-gradient-to-br from-muted via-background to-muted-foreground/10" />}
+                        <div className="absolute inset-0 bg-gradient-to-t from-black/65 via-black/10 to-transparent transition duration-300 group-hover:from-black/80" />
+
+                        <div className="absolute left-4 top-4 rounded-full bg-black/35 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.16em] text-white backdrop-blur">{format(new Date(event.occurred_at), "d MMM")}</div>
+
+                        {governance.length ? (
+                          <div className="absolute right-4 top-4 flex -space-x-1.5">
+                            {governance.slice(0, 3).map((item) => item.image_url ? <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" /> : <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">{(item.short_name || item.label || "G").charAt(0)}</div>)}
+                          </div>
+                        ) : null}
+
+                        {event.event_type === "member_joined" ? (
+                          <div className="absolute left-4 bottom-20 flex items-center gap-2 rounded-full bg-black/35 px-2 py-1.5 text-white backdrop-blur">
+                            <Avatar className="h-7 w-7 border border-white/20"><AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} /><AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback></Avatar>
+                            <span className="max-w-[180px] truncate text-xs font-medium">{event.actor_name || "New member"}</span>
+                          </div>
+                        ) : null}
+
+                        <div className="absolute inset-x-4 bottom-4 text-white">
+                          <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/70">{pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}</div>
+                          <div className="mt-1 line-clamp-2 text-lg font-semibold leading-tight">{event.title}</div>
+                          {governanceCopy ? <div className="mt-1 line-clamp-1 text-xs text-white/60">{governanceCopy}</div> : null}
+                        </div>
+                      </motion.button>
+                    );
+                  })}
+                </div>
               </div>
             </div>
           </section>
         </main>
       </div>
 
-      {selectedEvent ? (
-        <EventDialog
-          event={selectedEvent}
-          teamName={teamName}
-          open={!!selectedEvent}
-          onOpenChange={(open) => {
-            if (!open) setSelectedEvent(null);
-          }}
-        />
-      ) : null}
+      {selectedEvent ? <EventDialog event={selectedEvent} teamName={teamName} open={!!selectedEvent} onOpenChange={(open) => { if (!open) setSelectedEvent(null); }} /> : null}
     </div>
   );
 }

--- a/src/pages/space/[space]/timeline.js
+++ b/src/pages/space/[space]/timeline.js
@@ -1,9 +1,9 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/router";
-import { AnimatePresence, motion } from "framer-motion";
+import { motion } from "framer-motion";
 import { ArrowLeft, ArrowRight, ArrowUpRight, History } from "lucide-react";
 import { format } from "date-fns";
 
@@ -116,25 +116,15 @@ function governanceSentence(event, teamName) {
   const item = governance[0];
   const name = item.short_name || item.label || "an authority";
   const type = item.entity_type || "authority";
-  const phrase = pickVariant(
-    event,
-    GOVERNANCE_TEXT[type] || GOVERNANCE_TEXT.authority,
-  );
+  const phrase = pickVariant(event, GOVERNANCE_TEXT[type] || GOVERNANCE_TEXT.authority);
   const relationship = String(item.relationship_type || "").toLowerCase();
   const actor = teamName || "The team";
 
-  if (
-    relationship.includes("respons") ||
-    relationship.includes("owner") ||
-    relationship.includes("jurisdiction")
-  ) {
+  if (relationship.includes("respons") || relationship.includes("owner") || relationship.includes("jurisdiction")) {
     return `${actor} worked under ${name}.`;
   }
 
-  if (
-    relationship.includes("collabor") ||
-    relationship.includes("partner")
-  ) {
+  if (relationship.includes("collabor") || relationship.includes("partner")) {
     return `${actor} worked alongside ${name}.`;
   }
 
@@ -149,32 +139,14 @@ function MemberIdentity({ event, light = false }) {
   if (event.event_type !== "member_joined") return null;
 
   return (
-    <div
-      className={`flex items-center gap-2 ${
-        light ? "text-white/85" : "text-foreground"
-      }`}
-    >
-      <Avatar
-        className={`h-9 w-9 border ${
-          light ? "border-white/20" : "border-border"
-        }`}
-      >
+    <div className={`flex items-center gap-2 ${light ? "text-white/85" : "text-foreground"}`}>
+      <Avatar className={`h-9 w-9 border ${light ? "border-white/20" : "border-border"}`}>
         <AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} />
-        <AvatarFallback>
-          {event.actor_name?.charAt(0)?.toUpperCase() || "U"}
-        </AvatarFallback>
+        <AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback>
       </Avatar>
       <div className="min-w-0">
-        <div className="truncate text-sm font-medium">
-          {event.actor_name || "New member"}
-        </div>
-        <div
-          className={`text-[11px] ${
-            light ? "text-white/55" : "text-muted-foreground"
-          }`}
-        >
-          {event.role || "Member"}
-        </div>
+        <div className="truncate text-sm font-medium">{event.actor_name || "New member"}</div>
+        <div className={`text-[11px] ${light ? "text-white/55" : "text-muted-foreground"}`}>{event.role || "Member"}</div>
       </div>
     </div>
   );
@@ -185,44 +157,56 @@ function GovernanceRow({ event, light = false }) {
   if (!governance.length) return null;
 
   return (
-    <div
-      className={`flex flex-wrap items-center gap-2 ${
-        light ? "text-white/80" : "text-muted-foreground"
-      }`}
-    >
+    <div className={`flex flex-wrap items-center gap-2 ${light ? "text-white/80" : "text-muted-foreground"}`}>
       {governance.slice(0, 4).map((item) => (
         <div
           key={item.id}
           className={`flex items-center gap-2 rounded-full border px-2.5 py-1.5 backdrop-blur ${
-            light
-              ? "border-white/15 bg-white/5"
-              : "border-border bg-background/70"
+            light ? "border-white/15 bg-white/5" : "border-border bg-background/70"
           }`}
         >
           {item.image_url ? (
-            <img
-              src={item.image_url}
-              alt=""
-              className="h-5 w-5 rounded-full object-contain"
-            />
+            <img src={item.image_url} alt="" className="h-5 w-5 rounded-full object-contain" />
           ) : (
             <div className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[9px] font-semibold">
               {(item.short_name || item.label || "G").charAt(0)}
             </div>
           )}
-          <span className="max-w-32 truncate text-[11px] font-medium">
-            {item.short_name || item.label}
-          </span>
+          <span className="max-w-32 truncate text-[11px] font-medium">{item.short_name || item.label}</span>
         </div>
       ))}
     </div>
   );
 }
 
-function EventDialog({ event, teamName, open, onOpenChange }) {
-  const imageAttachments = safeArray(event.attachments).filter((item) =>
-    item?.mime_type?.startsWith("image/"),
+function LinkList({ links, light = false }) {
+  if (!links.length) return null;
+
+  return (
+    <div className={`space-y-2 ${light ? "text-white/80" : "text-muted-foreground"}`}>
+      {links.slice(0, 4).map((link) => (
+        <a
+          key={link.id}
+          href={link.url}
+          target="_blank"
+          rel="noreferrer"
+          className={`flex items-center gap-2 rounded-xl border px-3 py-2 text-xs transition ${
+            light
+              ? "border-white/15 bg-white/5 hover:bg-white/10"
+              : "border-border bg-background hover:bg-muted"
+          }`}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <span className="min-w-0 flex-1 truncate">{link.url}</span>
+          <ArrowUpRight className="h-3.5 w-3.5 shrink-0" />
+        </a>
+      ))}
+    </div>
   );
+}
+
+function EventDialog({ event, teamName, open, onOpenChange }) {
+  const imageAttachments = safeArray(event.attachments).filter((item) => item?.mime_type?.startsWith("image/"));
   const links = safeArray(event.links);
   const governanceCopy = governanceSentence(event, teamName);
 
@@ -235,12 +219,8 @@ function EventDialog({ event, teamName, open, onOpenChange }) {
               <AutoImageCarousel attachments={imageAttachments} />
               <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black/70 to-transparent" />
               <div className="absolute inset-x-6 bottom-5 text-white sm:inset-x-8">
-                <div className="text-xs font-medium uppercase tracking-[0.18em] text-white/70">
-                  {format(new Date(event.occurred_at), "d MMMM yyyy")}
-                </div>
-                <DialogTitle className="mt-2 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
-                  {event.title}
-                </DialogTitle>
+                <div className="text-xs font-medium uppercase tracking-[0.18em] text-white/70">{format(new Date(event.occurred_at), "d MMMM yyyy")}</div>
+                <DialogTitle className="mt-2 text-3xl font-semibold tracking-tight text-white sm:text-4xl">{event.title}</DialogTitle>
               </div>
             </div>
           ) : null}
@@ -248,18 +228,12 @@ function EventDialog({ event, teamName, open, onOpenChange }) {
           <div className="space-y-5 p-6 sm:p-8">
             {!imageAttachments.length ? (
               <div>
-                <div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                  {format(new Date(event.occurred_at), "d MMMM yyyy")}
-                </div>
-                <DialogTitle className="mt-2 text-3xl font-semibold tracking-tight sm:text-4xl">
-                  {event.title}
-                </DialogTitle>
+                <div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{format(new Date(event.occurred_at), "d MMMM yyyy")}</div>
+                <DialogTitle className="mt-2 text-3xl font-semibold tracking-tight sm:text-4xl">{event.title}</DialogTitle>
               </div>
             ) : null}
 
-            <DialogDescription className="text-base leading-7 text-muted-foreground">
-              {event.description || naturalLabel(event)}
-            </DialogDescription>
+            <DialogDescription className="text-base leading-7 text-muted-foreground">{event.description || naturalLabel(event)}</DialogDescription>
 
             {event.event_type === "member_joined" ? (
               <MemberIdentity event={event} />
@@ -267,44 +241,16 @@ function EventDialog({ event, teamName, open, onOpenChange }) {
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Avatar className="h-8 w-8 border">
                   <AvatarImage src={event.actor_avatar} alt={event.actor_name} />
-                  <AvatarFallback>
-                    {event.actor_name.charAt(0).toUpperCase()}
-                  </AvatarFallback>
+                  <AvatarFallback>{event.actor_name.charAt(0).toUpperCase()}</AvatarFallback>
                 </Avatar>
                 <span>{event.actor_name}</span>
               </div>
             ) : null}
 
-            {governanceCopy ? (
-              <p className="text-sm leading-6 text-muted-foreground">
-                {governanceCopy}
-              </p>
-            ) : null}
-
+            {governanceCopy ? <p className="text-sm leading-6 text-muted-foreground">{governanceCopy}</p> : null}
             <GovernanceRow event={event} />
-
-            {event.address ? (
-              <div className="rounded-2xl border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
-                {event.address}
-              </div>
-            ) : null}
-
-            {links.length ? (
-              <div className="flex flex-wrap gap-2">
-                {links.slice(0, 4).map((link) => (
-                  <a
-                    key={link.id}
-                    href={link.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="inline-flex items-center gap-1.5 rounded-full border bg-background px-3 py-2 text-xs font-medium transition hover:bg-muted"
-                  >
-                    {link.hostname || link.title || "Source"}
-                    <ArrowUpRight className="h-3.5 w-3.5" />
-                  </a>
-                ))}
-              </div>
-            ) : null}
+            {event.address ? <div className="rounded-2xl border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">{event.address}</div> : null}
+            <LinkList links={links} />
           </div>
         </div>
       </DialogContent>
@@ -317,62 +263,34 @@ export default function SpaceTimelinePage() {
   const railRef = useRef(null);
   const { space: slug } = router.query;
 
-  const { data: space, isLoading, error } = useSpaces({
-    slug,
-    enabled: !!slug,
-  });
+  const { data: space, isLoading, error } = useSpaces({ slug, enabled: !!slug });
+  const { data: timeline = [], isLoading: timelineLoading } = useSpaceTimeline(space?.id);
 
-  const { data: timeline = [], isLoading: timelineLoading } = useSpaceTimeline(
-    space?.id,
-  );
-
-  const [activeId, setActiveId] = useState(null);
   const [filter, setFilter] = useState("all");
   const [selectedEvent, setSelectedEvent] = useState(null);
 
   const filteredEvents = useMemo(
-    () =>
-      timeline.filter(
-        (event) => filter === "all" || event.event_type === filter,
-      ),
+    () => timeline.filter((event) => filter === "all" || event.event_type === filter),
     [timeline, filter],
   );
 
   const years = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          filteredEvents.map((event) =>
-            new Date(event.occurred_at).getFullYear(),
-          ),
-        ),
-      ).sort((a, b) => a - b),
+    () => Array.from(new Set(filteredEvents.map((event) => new Date(event.occurred_at).getFullYear()))).sort((a, b) => a - b),
     [filteredEvents],
   );
 
-  const groupedEvents = useMemo(() => {
-    const groups = [];
-    filteredEvents.forEach((event) => {
+  const monthMarkers = useMemo(() => {
+    const seen = new Set();
+    return filteredEvents.reduce((markers, event) => {
       const date = new Date(event.occurred_at);
-      const monthKey = format(date, "yyyy-MM");
-      let month = groups.find((group) => group.key === monthKey);
-      if (!month) {
-        month = {
-          key: monthKey,
-          label: format(date, "MMMM yyyy"),
-          year: date.getFullYear(),
-          events: [],
-        };
-        groups.push(month);
-      }
-      month.events.push(event);
-    });
-    return groups;
+      const key = format(date, "yyyy-MM");
+      if (seen.has(key)) return markers;
+      seen.add(key);
+      markers.push({ key, label: format(date, "MMM yyyy"), year: date.getFullYear() });
+      return markers;
+    }, []);
   }, [filteredEvents]);
 
-  const activeEvent = filteredEvents.find(
-    (event) => event.event_id === activeId,
-  );
   const teamName = space?.name ? `${space.name} team` : "The team";
 
   useEffect(() => {
@@ -380,16 +298,10 @@ export default function SpaceTimelinePage() {
     if (!rail) return undefined;
 
     const handleWheel = (event) => {
-      if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
-      if (Math.abs(event.deltaY) < 2) return;
-
+      if (Math.abs(event.deltaY) <= Math.abs(event.deltaX) || Math.abs(event.deltaY) < 2) return;
       const atStart = rail.scrollLeft <= 0 && event.deltaY < 0;
-      const atEnd =
-        rail.scrollLeft + rail.clientWidth >= rail.scrollWidth - 1 &&
-        event.deltaY > 0;
-
+      const atEnd = rail.scrollLeft + rail.clientWidth >= rail.scrollWidth - 1 && event.deltaY > 0;
       if (atStart || atEnd) return;
-
       event.preventDefault();
       rail.scrollLeft += event.deltaY;
     };
@@ -399,30 +311,15 @@ export default function SpaceTimelinePage() {
   }, []);
 
   const jump = (direction) => {
-    railRef.current?.scrollBy({
-      left: direction * Math.max(window.innerWidth * 0.72, 460),
-      behavior: "smooth",
-    });
+    railRef.current?.scrollBy({ left: direction * Math.max(window.innerWidth * 0.72, 460), behavior: "smooth" });
   };
 
   const jumpToYear = (year) => {
-    railRef.current
-      ?.querySelector(`[data-year="${year}"]`)
-      ?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
-  };
-
-  const jumpToMonth = (monthKey) => {
-    railRef.current
-      ?.querySelector(`[data-month="${monthKey}"]`)
-      ?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+    railRef.current?.querySelector(`[data-year="${year}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
   };
 
   if (isLoading || timelineLoading) {
-    return (
-      <div className="min-h-dvh bg-background">
-        <PageHeaderSkeleton />
-      </div>
-    );
+    return <div className="min-h-dvh bg-background"><PageHeaderSkeleton /></div>;
   }
 
   if (error || !space) {
@@ -430,9 +327,7 @@ export default function SpaceTimelinePage() {
       <div className="flex min-h-dvh items-center justify-center bg-background px-6 text-center">
         <div>
           <h1 className="text-2xl font-semibold">Space not found</h1>
-          <p className="mt-2 text-muted-foreground">
-            The requested Space does not exist.
-          </p>
+          <p className="mt-2 text-muted-foreground">The requested Space does not exist.</p>
         </div>
       </div>
     );
@@ -441,24 +336,9 @@ export default function SpaceTimelinePage() {
   return (
     <div className="relative min-h-dvh overflow-hidden bg-background">
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <motion.div
-          animate={{ x: [-80, 80, -80], y: [20, -30, 20] }}
-          transition={{ duration: 22, repeat: Infinity, ease: "easeInOut" }}
-          className="absolute left-[-10%] top-[-5%] h-[520px] w-[520px] rounded-full bg-primary/10 blur-[130px]"
-        />
-        <motion.div
-          animate={{ x: [70, -70, 70], y: [0, 50, 0] }}
-          transition={{ duration: 26, repeat: Infinity, ease: "easeInOut" }}
-          className="absolute bottom-[-10%] right-[-8%] h-[480px] w-[480px] rounded-full bg-primary/5 blur-[130px]"
-        />
-        <div
-          className="absolute inset-0 opacity-[0.025]"
-          style={{
-            backgroundImage:
-              "linear-gradient(to right, hsl(var(--foreground)) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--foreground)) 1px, transparent 1px)",
-            backgroundSize: "64px 64px",
-          }}
-        />
+        <motion.div animate={{ x: [-80, 80, -80], y: [20, -30, 20] }} transition={{ duration: 22, repeat: Infinity, ease: "easeInOut" }} className="absolute left-[-10%] top-[-5%] h-[520px] w-[520px] rounded-full bg-primary/10 blur-[130px]" />
+        <motion.div animate={{ x: [70, -70, 70], y: [0, 50, 0] }} transition={{ duration: 26, repeat: Infinity, ease: "easeInOut" }} className="absolute bottom-[-10%] right-[-8%] h-[480px] w-[480px] rounded-full bg-primary/5 blur-[130px]" />
+        <div className="absolute inset-0 opacity-[0.025]" style={{ backgroundImage: `linear-gradient(to right, hsl(var(--foreground)) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--foreground)) 1px, transparent 1px)`, backgroundSize: "64px 64px" }} />
       </div>
 
       <div className="relative z-10 flex min-h-dvh flex-col">
@@ -468,93 +348,28 @@ export default function SpaceTimelinePage() {
             <div className="truncate text-sm font-medium">{space.name}</div>
             <div className="text-xs text-muted-foreground">The story so far</div>
           </div>
-          <Button variant="ghost" asChild className="rounded-full">
-            <Link href={`/space/${space.slug}`}>Back to {space.name}</Link>
-          </Button>
+          <Button variant="ghost" asChild className="rounded-full"><Link href={`/space/${space.slug}`}>Back to {space.name}</Link></Button>
         </header>
 
         <main className="flex min-h-0 flex-1 flex-col">
           <section className="mx-auto w-full max-w-7xl px-5 pb-8 pt-10 sm:px-8 sm:pt-16 lg:px-12">
             <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
               <div className="max-w-4xl">
-                <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                  <History className="h-3.5 w-3.5" />
-                  The story so far
-                </div>
-                <h1 className="mt-4 text-5xl font-semibold tracking-tight sm:text-7xl lg:text-8xl">
-                  {space.name}
-                </h1>
-                <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
-                  A visual record of the people, places and moments that shaped the {space.name} team.
-                </p>
+                <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground"><History className="h-3.5 w-3.5" />The story so far</div>
+                <h1 className="mt-4 text-5xl font-semibold tracking-tight sm:text-7xl lg:text-8xl">{space.name}</h1>
+                <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">A visual record of the people, places and moments that shaped the {space.name} team.</p>
               </div>
-
-              <div className="flex shrink-0 items-center gap-2">
-                <Button
-                  variant="outline"
-                  size="icon"
-                  className="rounded-full"
-                  onClick={() => jump(-1)}
-                >
-                  <ArrowLeft className="h-4 w-4" />
-                </Button>
-                <Button
-                  variant="outline"
-                  size="icon"
-                  className="rounded-full"
-                  onClick={() => jump(1)}
-                >
-                  <ArrowRight className="h-4 w-4" />
-                </Button>
-              </div>
+              <div className="flex shrink-0 items-center gap-2"><Button variant="outline" size="icon" className="rounded-full" onClick={() => jump(-1)}><ArrowLeft className="h-4 w-4" /></Button><Button variant="outline" size="icon" className="rounded-full" onClick={() => jump(1)}><ArrowRight className="h-4 w-4" /></Button></div>
             </div>
 
             <div className="mt-8 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div className="flex items-center gap-2 overflow-x-auto pb-1">
-                {years.map((year) => (
-                  <button
-                    key={year}
-                    type="button"
-                    onClick={() => jumpToYear(year)}
-                    className="rounded-full border border-border bg-background/70 px-4 py-2 text-xs font-medium text-muted-foreground transition hover:border-foreground/20 hover:text-foreground"
-                  >
-                    {year}
-                  </button>
-                ))}
+                {years.map((year) => <button key={year} type="button" onClick={() => jumpToYear(year)} className="shrink-0 rounded-full border border-border bg-background/70 px-4 py-2 text-xs font-medium text-muted-foreground transition hover:border-foreground/20 hover:text-foreground">{year}</button>)}
               </div>
-
               <div className="flex items-center gap-2 overflow-x-auto pb-1 lg:justify-end">
-                {[
-                  "all",
-                  "member_joined",
-                  "report",
-                  "meeting",
-                  "event",
-                  "action",
-                  "announcement",
-                ].map((value) => (
-                  <button
-                    key={value}
-                    type="button"
-                    onClick={() => {
-                      setFilter(value);
-                      setActiveId(null);
-                    }}
-                    className={`shrink-0 rounded-full px-4 py-2 text-xs font-medium transition ${
-                      filter === value
-                        ? "bg-foreground text-background"
-                        : "bg-muted text-muted-foreground hover:text-foreground"
-                    }`}
-                  >
-                    {value === "all"
-                      ? "Everything"
-                      : value === "member_joined"
-                        ? "People"
-                        : value === "announcement"
-                          ? "Updates"
-                          : value === "report"
-                            ? "Reports"
-                            : `${value.charAt(0).toUpperCase()}${value.slice(1)}s`}
+                {["all", "member_joined", "report", "meeting", "event", "action", "announcement"].map((value) => (
+                  <button key={value} type="button" onClick={() => setFilter(value)} className={`shrink-0 rounded-full px-4 py-2 text-xs font-medium transition ${filter === value ? "bg-foreground text-background" : "bg-muted text-muted-foreground hover:text-foreground"}`}>
+                    {value === "all" ? "Everything" : value === "member_joined" ? "People" : value === "announcement" ? "Updates" : value === "report" ? "Reports" : `${value.charAt(0).toUpperCase()}${value.slice(1)}s`}
                   </button>
                 ))}
               </div>
@@ -562,143 +377,99 @@ export default function SpaceTimelinePage() {
           </section>
 
           <section className="relative flex-1 pb-12">
-            <div className="pointer-events-none absolute inset-x-0 top-1/2 hidden h-px bg-border/40 lg:block" />
+            <div ref={railRef} className="scrollbar-hide flex h-[64vh] min-h-[500px] items-stretch gap-0 overflow-x-auto overflow-y-hidden px-[7vw] py-6 sm:px-[8vw]">
+              <div className="relative flex min-w-max items-center py-20">
+                <div className="absolute left-0 right-0 top-1/2 h-px bg-border/80" />
 
-            <div
-              ref={railRef}
-              className="scrollbar-hide relative flex h-[64vh] min-h-[520px] snap-x items-center gap-12 overflow-x-auto overflow-y-hidden px-[8vw] py-10"
-            >
-              {groupedEvents.map((month, monthIndex) => (
-                <div
-                  key={month.key}
-                  data-month={month.key}
-                  data-year={month.year}
-                  className="relative flex h-full shrink-0 items-center"
-                >
-                  <div className="relative flex h-full w-[390px] flex-col justify-between sm:w-[440px] lg:w-[480px]">
-                    <div className="flex items-center gap-3 pb-3">
-                      <div className="h-2.5 w-2.5 rounded-full bg-foreground shadow-[0_0_0_7px_hsl(var(--background))]" />
-                      <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                        {month.label}
-                      </div>
+                {monthMarkers.map((month, monthIndex) => (
+                  <div key={month.key} data-year={month.year} className="relative flex w-[24rem] shrink-0 flex-col items-center">
+                    <div className="absolute left-1/2 top-1/2 z-20 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-background bg-foreground shadow-[0_0_0_5px_hsl(var(--background))]" />
+                    <div className="absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded-full border bg-background/95 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground shadow-sm backdrop-blur">
+                      {month.label}
                     </div>
 
-                    <div className="absolute bottom-1/2 left-0 top-1/2 hidden w-px -translate-x-1/2 bg-border lg:block" />
+                    <div className="flex h-[580px] w-full flex-col items-center justify-between">
+                      {filteredEvents
+                        .filter((event) => format(new Date(event.occurred_at), "yyyy-MM") === month.key)
+                        .map((event, eventIndex) => {
+                          const imageAttachments = safeArray(event.attachments).filter((item) => item?.mime_type?.startsWith("image/"));
+                          const governance = safeArray(event.governance_entities);
+                          const governanceCopy = governanceSentence(event, teamName);
+                          const above = (eventIndex + monthIndex) % 2 === 0;
 
-                    <div className="grid h-[calc(100%-36px)] grid-rows-2 gap-7">
-                      {month.events.map((event, eventIndex) => {
-                        const isTop = (monthIndex + eventIndex) % 2 === 0;
-                        const imageAttachments = safeArray(event.attachments).filter((item) =>
-                          item?.mime_type?.startsWith("image/"),
-                        );
-                        const governance = safeArray(event.governance_entities);
-                        const selected = activeId === event.event_id;
+                          return (
+                            <div key={event.event_id} className={`relative flex w-full justify-center ${above ? "items-end pb-8" : "items-start pt-8"} h-[48%]`}>
+                              <div className={`absolute left-1/2 w-px bg-border ${above ? "top-1/2 bottom-0" : "top-0 bottom-1/2"}`} />
 
-                        return (
-                          <div
-                            key={event.event_id}
-                            className={`flex ${
-                              isTop ? "items-end pb-3" : "items-start pt-3"
-                            } ${eventIndex % 2 === 1 ? "justify-end" : "justify-start"}`}
-                          >
-                            <motion.button
-                              type="button"
-                              onClick={() => {
-                                setActiveId(event.event_id);
-                                setSelectedEvent(event);
-                              }}
-                              className={`group relative h-[220px] w-[300px] overflow-hidden rounded-[30px] border border-border/70 bg-muted text-left shadow-sm transition focus:outline-none focus:ring-2 focus:ring-primary sm:h-[230px] sm:w-[330px] ${
-                                selected ? "ring-2 ring-primary/50" : ""
-                              }`}
-                              initial={{ opacity: 0, y: isTop ? 18 : -18 }}
-                              whileInView={{ opacity: 1, y: 0 }}
-                              viewport={{ once: true, amount: 0.2 }}
-                              transition={{ duration: 0.45, delay: Math.min(eventIndex * 0.04, 0.16) }}
-                            >
-                              {imageAttachments.length ? (
-                                <AutoImageCarousel attachments={imageAttachments} />
-                              ) : (
-                                <div className="absolute inset-0 bg-gradient-to-br from-muted via-background to-muted-foreground/10" />
-                              )}
+                              <motion.button
+                                type="button"
+                                onClick={() => setSelectedEvent(event)}
+                                className="group relative z-10 h-[220px] w-[330px] shrink-0 overflow-hidden rounded-[30px] border border-border/70 bg-muted text-left shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary sm:h-[240px] sm:w-[360px]"
+                                initial={{ opacity: 0, y: above ? 20 : -20 }}
+                                whileInView={{ opacity: 1, y: 0 }}
+                                viewport={{ once: true, amount: 0.2 }}
+                                transition={{ duration: 0.45, delay: Math.min(eventIndex * 0.04, 0.16) }}
+                              >
+                                {imageAttachments.length ? (
+                                  <AutoImageCarousel attachments={imageAttachments} />
+                                ) : (
+                                  <div className="absolute inset-0 bg-gradient-to-br from-muted via-background to-muted-foreground/10" />
+                                )}
 
-                              <div className="absolute inset-0 bg-gradient-to-t from-black/65 via-black/10 to-transparent" />
+                                <div className="absolute inset-0 bg-gradient-to-t from-black/65 via-black/10 to-transparent transition duration-300 group-hover:from-black/80" />
 
-                              <div className="absolute left-4 top-4 rounded-full bg-black/35 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.16em] text-white backdrop-blur">
-                                {format(new Date(event.occurred_at), "d MMM")}
-                              </div>
+                                <div className="absolute left-4 top-4 rounded-full bg-black/35 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.16em] text-white backdrop-blur">
+                                  {format(new Date(event.occurred_at), "d MMM")}
+                                </div>
 
-                              {event.event_type === "member_joined" && event.actor_avatar ? (
-                                <Avatar className="absolute right-4 top-4 h-9 w-9 border-2 border-white/80 shadow-lg">
-                                  <AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} />
-                                  <AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback>
-                                </Avatar>
-                              ) : null}
-
-                              {governance.length ? (
-                                <div className="absolute right-4 top-4 flex -space-x-1.5">
-                                  {governance.slice(0, 3).map((item) =>
-                                    item.image_url ? (
-                                      <img
-                                        key={item.id}
-                                        src={item.image_url}
-                                        alt=""
-                                        className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain"
-                                      />
+                                {governance.length ? (
+                                  <div className="absolute right-4 top-4 flex -space-x-1.5">
+                                    {governance.slice(0, 3).map((item) => item.image_url ? (
+                                      <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" />
                                     ) : (
-                                      <div
-                                        key={item.id}
-                                        className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground"
-                                      >
-                                        {(item.short_name || item.label || "G").charAt(0)}
-                                      </div>
-                                    ),
-                                  )}
-                                </div>
-                              ) : null}
+                                      <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">{(item.short_name || item.label || "G").charAt(0)}</div>
+                                    ))}
+                                  </div>
+                                ) : null}
 
-                              <div className="absolute inset-x-5 bottom-5 text-white transition duration-300 group-hover:-translate-y-1">
-                                <div className="text-xs font-medium uppercase tracking-[0.16em] text-white/70">
-                                  {pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}
+                                {event.event_type === "member_joined" ? (
+                                  <div className="absolute left-4 bottom-20 flex items-center gap-2 rounded-full bg-black/35 px-2 py-1.5 text-white backdrop-blur">
+                                    <Avatar className="h-7 w-7 border border-white/20">
+                                      <AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} />
+                                      <AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback>
+                                    </Avatar>
+                                    <span className="max-w-[170px] truncate text-xs font-medium">{event.actor_name || "New member"}</span>
+                                  </div>
+                                ) : null}
+
+                                <div className="absolute inset-x-4 bottom-4 text-white">
+                                  <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/70">{pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}</div>
+                                  <div className="mt-1 line-clamp-2 text-lg font-semibold leading-tight">{event.title}</div>
+                                  {governanceCopy ? <div className="mt-1 line-clamp-1 text-xs text-white/60">{governanceCopy}</div> : null}
                                 </div>
-                                <div className="mt-2 line-clamp-2 text-lg font-semibold leading-tight">
-                                  {event.title}
-                                </div>
-                                <div className="mt-2 max-h-0 overflow-hidden text-sm leading-5 text-white/75 opacity-0 transition-all duration-300 group-hover:max-h-16 group-hover:opacity-100">
-                                  {event.description || naturalLabel(event)}
-                                </div>
-                              </div>
-                            </motion.button>
-                          </div>
-                        );
-                      })}
+                              </motion.button>
+                            </div>
+                          );
+                        })}
                     </div>
                   </div>
-
-                  {monthIndex < groupedEvents.length - 1 ? (
-                    <div className="ml-10 h-full w-px bg-border/30" />
-                  ) : null}
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
           </section>
         </main>
       </div>
 
-      <AnimatePresence>
-        {selectedEvent ? (
-          <EventDialog
-            event={selectedEvent}
-            teamName={teamName}
-            open={!!selectedEvent}
-            onOpenChange={(open) => {
-              if (!open) {
-                setSelectedEvent(null);
-                setActiveId(null);
-              }
-            }}
-          />
-        ) : null}
-      </AnimatePresence>
+      {selectedEvent ? (
+        <EventDialog
+          event={selectedEvent}
+          teamName={teamName}
+          open={!!selectedEvent}
+          onOpenChange={(open) => {
+            if (!open) setSelectedEvent(null);
+          }}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Adds the dedicated full-screen Space timeline at `/space/[space]/timeline`.

Includes:
- full-screen timeline layout outside AppShell
- chronological event rail with year/month navigation
- alternating visual event cards
- natural-language event descriptions
- member avatars for joined events
- governance context and authority logos
- existing AutoImageCarousel for multi-image posts
- shadcn Dialog for event details
- link previews using existing link image metadata
- mouse-wheel horizontal timeline navigation

Preview deployment for the latest commit is READY on Vercel.

Latest verified commit: `98383b7449fa4582423625a52ffab2771fad3c60`