### PR TITLE
refactor: structure Space timeline components

### DIFF
--- a/public/timeline/README.md
+++ b/public/timeline/README.md
@@ -1,0 +1,12 @@
+Add the visual fallback images for the Space timeline here.
+
+Required files (landscape, 16:9, recommended 1600x900):
+- report-default.jpg
+- meeting-default.jpg
+- event-default.jpg
+- action-default.jpg
+- member-default.jpg
+- announcement-default.jpg
+- project-default.jpg
+
+You can replace these placeholder instructions with the actual image files later. The app already references these paths through src/config/timeline/fallbackImages.js.

--- a/src/components/space/timeline/TimelineCard.jsx
+++ b/src/components/space/timeline/TimelineCard.jsx
@@ -22,7 +22,7 @@ export function getFallbackImage(event) {
   return TIMELINE_FALLBACK_IMAGES[event?.event_type] || TIMELINE_FALLBACK_IMAGES.post;
 }
 
-export default function TimelineCard({ event, above, active, onSelect, monthIndex = 0 }) {
+export default function TimelineCard({ event, active, onSelect, monthIndex = 0, vertical = false }) {
   const date = new Date(event.occurred_at);
   const attachments = safeArray(event.attachments).filter((item) => item?.mime_type?.startsWith("image/"));
   const governance = safeArray(event.governance_entities);
@@ -31,61 +31,50 @@ export default function TimelineCard({ event, above, active, onSelect, monthInde
   const natural = pickVariant(event, TIMELINE_NATURAL_TEXT[event.event_type] || TIMELINE_NATURAL_TEXT.post);
 
   return (
-    <div className="relative flex h-[560px] w-[410px] shrink-0 items-center justify-center">
-      <div className={`relative z-10 ${above ? "mb-[250px]" : "mt-[250px]"}`}>
-        <motion.button
-          type="button"
-          onClick={() => onSelect(event)}
-          className="group relative block h-[230px] w-[350px] overflow-hidden rounded-[30px] border bg-background text-left shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary"
-          initial={{ opacity: 0, y: above ? 14 : -14 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, amount: 0.2 }}
-          transition={{ duration: 0.38 }}
-          style={{
-            borderColor: active ? color.line : "hsl(var(--border))",
-            boxShadow: active ? `0 0 0 1px ${color.line}, 0 0 28px ${color.glow}` : undefined,
-          }}
-        >
-          {attachments.length ? (
-            <AutoImageCarousel attachments={attachments} />
-          ) : (
-            <img src={fallback} alt="" className="absolute inset-0 h-full w-full object-cover" />
-          )}
+    <motion.button
+      type="button"
+      onClick={() => onSelect(event)}
+      className={`group relative block h-[230px] w-full max-w-[420px] overflow-hidden rounded-[30px] border bg-background text-left shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary ${vertical ? "sm:max-w-[440px]" : "w-[350px]"}`}
+      initial={{ opacity: 0, y: 16 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.2 }}
+      transition={{ duration: 0.38 }}
+      style={{
+        borderColor: active ? color.line : "hsl(var(--border))",
+        boxShadow: active ? `0 0 0 1px ${color.line}, 0 0 28px ${color.glow}` : undefined,
+      }}
+    >
+      {attachments.length ? <AutoImageCarousel attachments={attachments} /> : <img src={fallback} alt="" className="absolute inset-0 h-full w-full object-cover" />}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/15 to-transparent" />
 
-          <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/15 to-transparent" />
-
-          <div className="absolute left-4 top-4 rounded-full border border-white/15 bg-black/25 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-white backdrop-blur">
-            {format(date, "d MMM")}
-          </div>
-
-          {governance.length ? (
-            <div className="absolute right-4 top-4 flex -space-x-1.5">
-              {governance.slice(0, 3).map((item) => item.image_url ? (
-                <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" />
-              ) : (
-                <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">
-                  {(item.short_name || item.label || "G").charAt(0)}
-                </div>
-              ))}
-            </div>
-          ) : null}
-
-          {event.event_type === "member_joined" ? (
-            <div className="absolute bottom-20 left-4 flex items-center gap-2 rounded-full bg-black/35 px-2 py-1.5 text-white backdrop-blur">
-              <Avatar className="h-7 w-7 border border-white/20">
-                <AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} />
-                <AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback>
-              </Avatar>
-              <span className="max-w-[170px] truncate text-xs font-medium">{event.actor_name || "New member"}</span>
-            </div>
-          ) : null}
-
-          <div className="absolute inset-x-4 bottom-4 text-white">
-            <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/70">{natural}</div>
-            <div className="mt-1 line-clamp-2 text-lg font-semibold leading-tight">{event.title}</div>
-          </div>
-        </motion.button>
+      <div className="absolute left-4 top-4 rounded-full border border-white/15 bg-black/25 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-white backdrop-blur">
+        {format(date, "d MMM")}
       </div>
-    </div>
+
+      {governance.length ? (
+        <div className="absolute right-4 top-4 flex -space-x-1.5">
+          {governance.slice(0, 3).map((item) => item.image_url ? (
+            <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" />
+          ) : (
+            <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">{(item.short_name || item.label || "G").charAt(0)}</div>
+          ))}
+        </div>
+      ) : null}
+
+      {event.event_type === "member_joined" ? (
+        <div className="absolute bottom-20 left-4 flex items-center gap-2 rounded-full bg-black/35 px-2 py-1.5 text-white backdrop-blur">
+          <Avatar className="h-7 w-7 border border-white/20">
+            <AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} />
+            <AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback>
+          </Avatar>
+          <span className="max-w-[170px] truncate text-xs font-medium">{event.actor_name || "New member"}</span>
+        </div>
+      ) : null}
+
+      <div className="absolute inset-x-4 bottom-4 text-white">
+        <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/70">{natural}</div>
+        <div className="mt-1 line-clamp-2 text-lg font-semibold leading-tight">{event.title}</div>
+      </div>
+    </motion.button>
   );
 }

--- a/src/components/space/timeline/TimelineCard.jsx
+++ b/src/components/space/timeline/TimelineCard.jsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { format } from "date-fns";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import AutoImageCarousel from "@/components/attachment/AutoImageCarousel";
+import { TIMELINE_FALLBACK_IMAGES, getTimelineColor, TIMELINE_NATURAL_TEXT } from "@/config/timeline";
+
+function safeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function pickVariant(event, items) {
+  const key = String(event.event_id || event.post_id || event.title || "timeline");
+  let hash = 0;
+  for (let i = 0; i < key.length; i += 1) hash = (hash * 31 + key.charCodeAt(i)) >>> 0;
+  return items[hash % items.length];
+}
+
+export function getFallbackImage(event) {
+  return TIMELINE_FALLBACK_IMAGES[event?.event_type] || TIMELINE_FALLBACK_IMAGES.post;
+}
+
+export default function TimelineCard({ event, above, active, onSelect, monthIndex = 0 }) {
+  const date = new Date(event.occurred_at);
+  const attachments = safeArray(event.attachments).filter((item) => item?.mime_type?.startsWith("image/"));
+  const governance = safeArray(event.governance_entities);
+  const color = getTimelineColor(date.getFullYear(), monthIndex);
+  const fallback = getFallbackImage(event);
+  const natural = pickVariant(event, TIMELINE_NATURAL_TEXT[event.event_type] || TIMELINE_NATURAL_TEXT.post);
+
+  return (
+    <div className="relative flex h-[560px] w-[410px] shrink-0 items-center justify-center">
+      <div className={`relative z-10 ${above ? "mb-[250px]" : "mt-[250px]"}`}>
+        <motion.button
+          type="button"
+          onClick={() => onSelect(event)}
+          className="group relative block h-[230px] w-[350px] overflow-hidden rounded-[30px] border bg-background text-left shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary"
+          initial={{ opacity: 0, y: above ? 14 : -14 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.2 }}
+          transition={{ duration: 0.38 }}
+          style={{
+            borderColor: active ? color.line : "hsl(var(--border))",
+            boxShadow: active ? `0 0 0 1px ${color.line}, 0 0 28px ${color.glow}` : undefined,
+          }}
+        >
+          {attachments.length ? (
+            <AutoImageCarousel attachments={attachments} />
+          ) : (
+            <img src={fallback} alt="" className="absolute inset-0 h-full w-full object-cover" />
+          )}
+
+          <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/15 to-transparent" />
+
+          <div className="absolute left-4 top-4 rounded-full border border-white/15 bg-black/25 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-white backdrop-blur">
+            {format(date, "d MMM")}
+          </div>
+
+          {governance.length ? (
+            <div className="absolute right-4 top-4 flex -space-x-1.5">
+              {governance.slice(0, 3).map((item) => item.image_url ? (
+                <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" />
+              ) : (
+                <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">
+                  {(item.short_name || item.label || "G").charAt(0)}
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {event.event_type === "member_joined" ? (
+            <div className="absolute bottom-20 left-4 flex items-center gap-2 rounded-full bg-black/35 px-2 py-1.5 text-white backdrop-blur">
+              <Avatar className="h-7 w-7 border border-white/20">
+                <AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} />
+                <AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback>
+              </Avatar>
+              <span className="max-w-[170px] truncate text-xs font-medium">{event.actor_name || "New member"}</span>
+            </div>
+          ) : null}
+
+          <div className="absolute inset-x-4 bottom-4 text-white">
+            <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/70">{natural}</div>
+            <div className="mt-1 line-clamp-2 text-lg font-semibold leading-tight">{event.title}</div>
+          </div>
+        </motion.button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/space/timeline/TimelineMonthMarkers.jsx
+++ b/src/components/space/timeline/TimelineMonthMarkers.jsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { format } from "date-fns";
+import { getTimelineColor } from "@/config/timeline";
+
+export default function TimelineMonthMarkers({ months = [], activeMonth, onSelect }) {
+  return (
+    <div className="flex items-center gap-2 overflow-x-auto pb-1">
+      {months.map((month, index) => {
+        const color = getTimelineColor(month.year, index);
+        const active = month.key === activeMonth;
+
+        return (
+          <button
+            key={month.key}
+            type="button"
+            onClick={() => onSelect(month.key)}
+            className="shrink-0 rounded-full border px-3 py-1.5 text-[11px] font-medium transition"
+            style={{
+              borderColor: active ? color.line : "hsl(var(--border))",
+              color: active ? "hsl(var(--foreground))" : "hsl(var(--muted-foreground))",
+              background: active ? color.glow : "transparent",
+            }}
+          >
+            {format(new Date(`${month.key}-01`), "MMM yyyy")}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/space/timeline/TimelineRail.jsx
+++ b/src/components/space/timeline/TimelineRail.jsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+import { Progress, ProgressIndicator, ProgressTrack } from "@/components/ui/progress";
+import { getTimelineColor } from "@/config/timeline";
+
+export default function TimelineRail({ progress = 0, color }) {
+  const timelineColor = color || getTimelineColor(0, 0);
+
+  return (
+    <Progress value={progress} className="pointer-events-none absolute left-0 right-0 top-1/2 z-0 -translate-y-1/2">
+      <ProgressTrack className="h-[3px] bg-muted/90">
+        <ProgressIndicator
+          className="h-full transition-none"
+          style={{
+            background: timelineColor.line,
+            boxShadow: `0 0 10px ${timelineColor.glow}`,
+          }}
+        />
+      </ProgressTrack>
+    </Progress>
+  );
+}
+
+export function TimelineConnector({ active = false, color, above = true }) {
+  const timelineColor = color || getTimelineColor(0, 0);
+
+  return (
+    <motion.div
+      aria-hidden="true"
+      className="pointer-events-none absolute left-1/2 z-[1] w-px -translate-x-1/2"
+      style={{
+        [above ? "bottom" : "top"]: "50%",
+        height: "58px",
+        background: active
+          ? timelineColor.line
+          : "hsl(var(--border))",
+        boxShadow: active ? `0 0 10px ${timelineColor.glow}` : undefined,
+      }}
+      animate={{ opacity: active ? 1 : 0.65 }}
+      transition={{ duration: 0.25 }}
+    />
+  );
+}

--- a/src/components/space/timeline/VerticalTimeline.jsx
+++ b/src/components/space/timeline/VerticalTimeline.jsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { format } from "date-fns";
+
+import TimelineCard from "./TimelineCard";
+import { getTimelineColor } from "@/config/timeline";
+
+export default function VerticalTimeline({ events = [], monthMarkers = [], activeMonth, onSelect }) {
+  const monthIndexByKey = new Map(monthMarkers.map((month, index) => [month.key, index]));
+
+  return (
+    <div className="relative mx-auto w-full max-w-6xl px-4 pb-24 sm:px-8 lg:px-12">
+      <div className="relative">
+        <div className="absolute bottom-0 left-1/2 top-0 hidden w-1 -translate-x-1/2 overflow-hidden rounded-full bg-muted/80 md:block" />
+
+        {events.map((event, index) => {
+          const date = new Date(event.occurred_at);
+          const monthKey = format(date, "yyyy-MM");
+          const monthIndex = monthIndexByKey.get(monthKey) ?? 0;
+          const color = getTimelineColor(date.getFullYear(), monthIndex);
+          const active = activeMonth === monthKey;
+          const left = index % 2 === 0;
+
+          return (
+            <div key={event.event_id} data-month={monthKey} data-year={date.getFullYear()} className="relative grid min-h-[430px] items-center md:grid-cols-[1fr_96px_1fr]">
+              <div className={`relative flex ${left ? "justify-end md:pr-10" : "justify-end md:col-start-3 md:row-start-1 md:pl-10"}`}>
+                <TimelineCard
+                  event={event}
+                  above={left}
+                  active={active}
+                  onSelect={onSelect}
+                  monthIndex={monthIndex}
+                  vertical
+                />
+              </div>
+
+              <div className="relative z-20 row-start-1 hidden h-full md:block">
+                <div className="absolute left-1/2 top-1/2 h-[100px] w-px -translate-x-1/2 -translate-y-1/2" style={{ background: `linear-gradient(${left ? "to top" : "to bottom"}, transparent, ${active ? color.line : "hsl(var(--border))"})` }} />
+                <motion.div
+                  className="absolute left-1/2 top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-background"
+                  animate={{ scale: active ? 1.3 : 1, boxShadow: active ? `0 0 0 5px ${color.glow}` : "0 0 0 0 transparent" }}
+                  transition={{ duration: 0.25 }}
+                  style={{ background: active ? color.line : "hsl(var(--muted-foreground))" }}
+                />
+              </div>
+
+              <div className="row-start-1 hidden md:block">
+                <div className={`absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded-full border bg-background/90 px-3 py-1.5 text-[11px] font-medium shadow-sm backdrop-blur ${active ? "text-foreground" : "text-muted-foreground"}`} style={{ borderColor: active ? color.line : "hsl(var(--border))" }}>
+                  {format(date, "MMM yyyy")}
+                </div>
+              </div>
+
+              <div className="absolute left-1/2 top-1/2 h-px hidden w-[calc(50%-48px)] -translate-y-1/2 md:block" style={{ background: active ? color.line : "hsl(var(--border))" }} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/config/timeline/colors.js
+++ b/src/config/timeline/colors.js
@@ -1,0 +1,12 @@
+export const TIMELINE_COLORS = [
+  { name: "blue", line: "#2563eb", glow: "rgba(37,99,235,0.18)", dark: "#1d4ed8" },
+  { name: "green", line: "#059669", glow: "rgba(5,150,105,0.18)", dark: "#047857" },
+  { name: "amber", line: "#d97706", glow: "rgba(217,119,6,0.18)", dark: "#b45309" },
+  { name: "violet", line: "#7c3aed", glow: "rgba(124,58,237,0.18)", dark: "#6d28d9" },
+  { name: "pink", line: "#db2777", glow: "rgba(219,39,119,0.18)", dark: "#be185d" },
+];
+
+export function getTimelineColor(year, monthIndex = 0) {
+  const index = Math.abs(Number(year || 0) + Number(monthIndex || 0)) % TIMELINE_COLORS.length;
+  return TIMELINE_COLORS[index];
+}

--- a/src/config/timeline/colors.js
+++ b/src/config/timeline/colors.js
@@ -7,6 +7,12 @@ export const TIMELINE_COLORS = [
 ];
 
 export function getTimelineColor(year, monthIndex = 0) {
-  const index = Math.abs(Number(year || 0) + Number(monthIndex || 0)) % TIMELINE_COLORS.length;
+  const index = Math.abs(Number(year || 0) * 12 + Number(monthIndex || 0)) % TIMELINE_COLORS.length;
   return TIMELINE_COLORS[index];
+}
+
+export function getTimelineColorForMonth(monthKey, monthMarkers = []) {
+  const index = Math.max(0, monthMarkers.findIndex((month) => month.key === monthKey));
+  const year = Number(String(monthKey || "0").slice(0, 4));
+  return getTimelineColor(year, index);
 }

--- a/src/config/timeline/fallbackImages.js
+++ b/src/config/timeline/fallbackImages.js
@@ -1,0 +1,10 @@
+export const TIMELINE_FALLBACK_IMAGES = {
+  report: "/timeline/report-default.jpg",
+  meeting: "/timeline/meeting-default.jpg",
+  event: "/timeline/event-default.jpg",
+  action: "/timeline/action-default.jpg",
+  member_joined: "/timeline/member-default.jpg",
+  announcement: "/timeline/announcement-default.jpg",
+  post: "/timeline/project-default.jpg",
+  space_created: "/timeline/project-default.jpg",
+};

--- a/src/config/timeline/governanceLanguage.js
+++ b/src/config/timeline/governanceLanguage.js
@@ -1,0 +1,30 @@
+export const GOVERNANCE_LANGUAGE = {
+  authority: ["under", "with", "in conversation with"],
+  department: ["within", "through", "with"],
+  official: ["with", "in conversation with", "alongside"],
+  organization: ["alongside", "with", "working with"],
+  person: ["with", "alongside", "in conversation with"],
+};
+
+export const GOVERNANCE_RELATIONSHIP_LANGUAGE = {
+  responsibility: [
+    "worked under",
+    "sat within the responsibility of",
+    "fell under",
+  ],
+  collaboration: [
+    "worked alongside",
+    "worked with",
+    "collaborated with",
+  ],
+  engagement: [
+    "was in conversation with",
+    "engaged with",
+    "met with",
+  ],
+  general: [
+    "worked with",
+    "worked alongside",
+    "was in conversation with",
+  ],
+};

--- a/src/config/timeline/index.js
+++ b/src/config/timeline/index.js
@@ -1,0 +1,4 @@
+export { TIMELINE_NATURAL_TEXT } from "./naturalText";
+export { GOVERNANCE_LANGUAGE, GOVERNANCE_RELATIONSHIP_LANGUAGE } from "./governanceLanguage";
+export { TIMELINE_COLORS, getTimelineColor } from "./colors";
+export { TIMELINE_FALLBACK_IMAGES } from "./fallbackImages";

--- a/src/config/timeline/index.js
+++ b/src/config/timeline/index.js
@@ -1,4 +1,4 @@
 export { TIMELINE_NATURAL_TEXT } from "./naturalText";
 export { GOVERNANCE_LANGUAGE, GOVERNANCE_RELATIONSHIP_LANGUAGE } from "./governanceLanguage";
-export { TIMELINE_COLORS, getTimelineColor } from "./colors";
+export { TIMELINE_COLORS, getTimelineColor, getTimelineColorForMonth } from "./colors";
 export { TIMELINE_FALLBACK_IMAGES } from "./fallbackImages";

--- a/src/config/timeline/naturalText.js
+++ b/src/config/timeline/naturalText.js
@@ -1,0 +1,58 @@
+export const TIMELINE_NATURAL_TEXT = {
+  space_created: [
+    "This is where the story began",
+    "This is where the work started",
+    "The first page of the story",
+    "The beginning of something local",
+    "This is where it all came together",
+  ],
+  member_joined: [
+    "Someone new joined the team",
+    "Another person came on board",
+    "The team grew a little stronger",
+    "A new contributor joined in",
+    "Another pair of hands joined the effort",
+  ],
+  report: [
+    "A piece of work took shape",
+    "The team moved an idea forward",
+    "Something useful came together",
+    "The team put its findings on record",
+    "The work turned into something concrete",
+  ],
+  meeting: [
+    "The team sat down to work through it",
+    "People came together to figure it out",
+    "A conversation moved the work forward",
+    "The right people got around the table",
+    "The team made time to work through the details",
+  ],
+  event: [
+    "The team showed up",
+    "The team stepped into the wider conversation",
+    "The work met the real world",
+    "The team took part in the moment",
+    "The team was there for it",
+  ],
+  action: [
+    "Something was done",
+    "The team moved from words to action",
+    "A small step became a real action",
+    "The team followed through",
+    "The work moved into the real world",
+  ],
+  announcement: [
+    "Something important was shared",
+    "The team had an update to share",
+    "A new chapter was announced",
+    "The team shared where things stood",
+    "A useful update made its way out",
+  ],
+  post: [
+    "A moment worth keeping",
+    "Something the team wanted on record",
+    "Another piece of the story",
+    "A moment from along the way",
+    "One more chapter in the journey",
+  ],
+};


### PR DESCRIPTION
Refactors the Space timeline before the next AI/governance phase.

Includes:
- central timeline configuration for natural language, governance language, colors, and fallback image paths
- reusable timeline rail using the existing shadcn Progress component
- reusable timeline card and month marker components
- existing PostLinks/LinkCard reuse retained for post links and link image previews
- connector spacing kept separate from cards so the branch line remains visible
- fallback image configuration under /public/timeline/

Fallback assets are documented but not included until the final images are provided.

Target route: /space/[space]/timeline