### PR TITLE
feat(timeline): adaptive horizontal and vertical timeline

### DIFF
--- a/src/components/space/timeline/AdaptiveTimelineRail.jsx
+++ b/src/components/space/timeline/AdaptiveTimelineRail.jsx
@@ -6,7 +6,7 @@ import { ChevronLeft, ChevronRight, Monitor, Rows3, Columns3 } from "lucide-reac
 
 import { Button } from "@/components/ui/button";
 import { Progress, ProgressIndicator, ProgressTrack } from "@/components/ui/progress";
-import { getTimelineColor } from "@/config/timeline";
+import { getTimelineColor, getTimelineColorForMonth } from "@/config/timeline";
 import { TIMELINE_ORIENTATION, TIMELINE_BREAKPOINTS } from "@/config/timeline/orientation";
 import TimelineCard from "@/components/space/timeline/TimelineCard";
 
@@ -38,8 +38,8 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
   );
 
   const progress = monthMarkers.length ? ((activeIndex + 1) / monthMarkers.length) * 100 : 0;
-  const activeColor = monthMarkers[activeIndex]
-    ? getTimelineColor(monthMarkers[activeIndex].year, activeIndex)
+  const activeColor = activeMonth
+    ? getTimelineColorForMonth(activeMonth, monthMarkers)
     : getTimelineColor(0, 0);
 
   const handleScroll = () => {
@@ -157,7 +157,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
               const date = new Date(event.occurred_at);
               const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
               const monthIndex = monthMarkers.findIndex((month) => month.key === monthKey);
-              const color = getTimelineColor(date.getFullYear(), Math.max(monthIndex, 0));
+              const color = getTimelineColorForMonth(monthKey, monthMarkers);
               const active = activeMonth === monthKey;
               const above = index % 2 === 0;
 
@@ -171,11 +171,15 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
                       color={color}
                       onSelect={onSelectEvent}
                       orientation={TIMELINE_ORIENTATION.VERTICAL}
+                      monthIndex={Math.max(monthIndex, 0)}
                     />
                   </div>
 
                   <div className="relative z-20 hidden min-h-[250px] md:flex md:items-center md:justify-center">
-                    <div className="absolute left-1/2 top-1/2 h-px w-12 -translate-y-1/2 bg-border" />
+                    <div
+                      className="absolute left-1/2 top-1/2 h-px w-12 -translate-y-1/2"
+                      style={{ background: active ? color.line : "hsl(var(--border))" }}
+                    />
                     <motion.div
                       className="relative h-3.5 w-3.5 rounded-full border-2 bg-background"
                       animate={{ scale: active ? 1.25 : 1 }}
@@ -211,11 +215,15 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
         </div>
       </div>
 
-      <div ref={railRef} className="scrollbar-hide flex h-[64vh] min-h-[560px] items-stretch gap-0 overflow-x-auto overflow-y-hidden px-[7vw] py-6 sm:px-[8vw]">
-        <div className="relative flex min-w-max items-center py-24">
-          <Progress value={progress} className="pointer-events-none absolute left-0 right-0 top-1/2 z-0 -translate-y-1/2">
-            <ProgressTrack className="h-[3px] bg-muted/90">
-              <ProgressIndicator className="h-full transition-none" style={{ background: activeColor.line, boxShadow: `0 0 12px ${activeColor.glow}` }} />
+      <div ref={railRef} className="scrollbar-hide overflow-x-auto overflow-y-hidden px-[7vw] py-8 sm:px-[8vw]">
+        <div className="relative mx-auto flex min-w-max items-center">
+          <div className="pointer-events-none absolute left-0 right-0 top-[320px] z-0 h-[3px] rounded-full bg-muted/90" />
+          <Progress value={progress} className="pointer-events-none absolute left-0 right-0 top-[320px] z-0">
+            <ProgressTrack className="h-[3px] bg-transparent">
+              <ProgressIndicator
+                className="h-full transition-none"
+                style={{ background: activeColor.line, boxShadow: `0 0 12px ${activeColor.glow}` }}
+              />
             </ProgressTrack>
           </Progress>
 
@@ -223,26 +231,36 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
             const date = new Date(event.occurred_at);
             const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
             const monthIndex = monthMarkers.findIndex((month) => month.key === monthKey);
-            const color = getTimelineColor(date.getFullYear(), Math.max(monthIndex, 0));
+            const color = getTimelineColorForMonth(monthKey, monthMarkers);
             const active = activeMonth === monthKey;
             const above = index % 2 === 0;
 
             return (
-              <div key={event.event_id} data-month={monthKey} className="relative flex h-[560px] w-[410px] shrink-0 items-center justify-center">
-                <div className={`relative z-10 ${above ? "mb-[260px]" : "mt-[260px]"}`}>
-                  <div
-                    aria-hidden="true"
-                    className={`pointer-events-none absolute left-1/2 h-[60px] w-px -translate-x-1/2 ${above ? "top-full" : "bottom-full"}`}
-                    style={{ background: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 10px ${color.glow}` : undefined }}
-                  />
-                  <TimelineCard
-                    event={event}
-                    above={above}
-                    active={active}
-                    color={color}
-                    onSelect={onSelectEvent}
-                    orientation={TIMELINE_ORIENTATION.HORIZONTAL}
-                  />
+              <div key={event.event_id} data-month={monthKey} className="relative w-[390px] shrink-0 px-5">
+                <div className="relative h-[640px]">
+                  <div className="absolute left-1/2 top-[320px] -translate-x-1/2">
+                    <div
+                      className="absolute left-1/2 h-20 w-px -translate-x-1/2"
+                      style={{
+                        top: above ? "4px" : "auto",
+                        bottom: above ? "auto" : "4px",
+                        background: active ? color.line : "hsl(var(--border))",
+                        boxShadow: active ? `0 0 10px ${color.glow}` : undefined,
+                      }}
+                    />
+                  </div>
+
+                  <div className={`absolute left-1/2 w-full -translate-x-1/2 ${above ? "bottom-[340px]" : "top-[340px]"}`}>
+                    <TimelineCard
+                      event={event}
+                      above={above}
+                      active={active}
+                      color={color}
+                      onSelect={onSelectEvent}
+                      orientation={TIMELINE_ORIENTATION.HORIZONTAL}
+                      monthIndex={Math.max(monthIndex, 0)}
+                    />
+                  </div>
                 </div>
               </div>
             );
@@ -251,8 +269,8 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
       </div>
 
       <div className="mt-4 flex items-center justify-center gap-2 overflow-x-auto px-5 pb-1">
-        {monthMarkers.map((month, index) => {
-          const color = getTimelineColor(month.year, index);
+        {monthMarkers.map((month) => {
+          const color = getTimelineColorForMonth(month.key, monthMarkers);
           const active = month.key === activeMonth;
           return (
             <button
@@ -260,7 +278,10 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
               type="button"
               onClick={() => jumpToMonth(month.key)}
               className={`shrink-0 rounded-full border px-3 py-1.5 text-[11px] font-medium transition ${active ? "text-foreground shadow-sm" : "text-muted-foreground"}`}
-              style={{ borderColor: active ? color.line : color.glow, background: active ? color.glow : "transparent" }}
+              style={{
+                borderColor: active ? color.line : color.glow,
+                background: active ? color.glow : "transparent",
+              }}
             >
               {month.label}
             </button>

--- a/src/components/space/timeline/AdaptiveTimelineRail.jsx
+++ b/src/components/space/timeline/AdaptiveTimelineRail.jsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { motion } from "framer-motion";
+import { ChevronLeft, ChevronRight, Monitor, Rows3, Columns3 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Progress, ProgressIndicator, ProgressTrack } from "@/components/ui/progress";
+import { getTimelineColor } from "@/config/timeline";
+import { TIMELINE_ORIENTATION, TIMELINE_BREAKPOINTS } from "@/config/timeline/orientation";
+import TimelineCard from "@/components/space/timeline/TimelineCard";
+
+function getPreferredOrientation(value, width) {
+  if (value === TIMELINE_ORIENTATION.HORIZONTAL) return TIMELINE_ORIENTATION.HORIZONTAL;
+  if (value === TIMELINE_ORIENTATION.VERTICAL) return TIMELINE_ORIENTATION.VERTICAL;
+  return width < TIMELINE_BREAKPOINTS.verticalBelowPx
+    ? TIMELINE_ORIENTATION.VERTICAL
+    : TIMELINE_ORIENTATION.HORIZONTAL;
+}
+
+export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth, onMonthChange, onSelectEvent }) {
+  const [preference, setPreference] = useState(TIMELINE_ORIENTATION.AUTO);
+  const [width, setWidth] = useState(1440);
+  const railRef = useRef(null);
+
+  useEffect(() => {
+    const update = () => setWidth(window.innerWidth);
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  const orientation = getPreferredOrientation(preference, width);
+
+  const activeIndex = useMemo(
+    () => Math.max(0, monthMarkers.findIndex((month) => month.key === activeMonth)),
+    [monthMarkers, activeMonth],
+  );
+
+  const progress = monthMarkers.length ? ((activeIndex + 1) / monthMarkers.length) * 100 : 0;
+  const activeColor = monthMarkers[activeIndex]
+    ? getTimelineColor(monthMarkers[activeIndex].year, activeIndex)
+    : getTimelineColor(0, 0);
+
+  const handleScroll = () => {
+    if (orientation !== TIMELINE_ORIENTATION.HORIZONTAL) return;
+    const rail = railRef.current;
+    if (!rail) return;
+    const nodes = rail.querySelectorAll("[data-month]");
+    const center = rail.scrollLeft + rail.clientWidth / 2;
+    let closest = null;
+    let distance = Infinity;
+    nodes.forEach((node) => {
+      const nodeCenter = node.offsetLeft + node.offsetWidth / 2;
+      const diff = Math.abs(nodeCenter - center);
+      if (diff < distance) {
+        distance = diff;
+        closest = node.dataset.month;
+      }
+    });
+    if (closest) onMonthChange(closest);
+  };
+
+  useEffect(() => {
+    const rail = railRef.current;
+    if (!rail || orientation !== TIMELINE_ORIENTATION.HORIZONTAL) return undefined;
+
+    const onWheel = (event) => {
+      if (Math.abs(event.deltaY) <= Math.abs(event.deltaX) || Math.abs(event.deltaY) < 2) return;
+      const atStart = rail.scrollLeft <= 0 && event.deltaY < 0;
+      const atEnd = rail.scrollLeft + rail.clientWidth >= rail.scrollWidth - 1 && event.deltaY > 0;
+      if (atStart || atEnd) return;
+      event.preventDefault();
+      rail.scrollLeft += event.deltaY;
+    };
+
+    rail.addEventListener("wheel", onWheel, { passive: false });
+    rail.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll();
+    return () => {
+      rail.removeEventListener("wheel", onWheel);
+      rail.removeEventListener("scroll", handleScroll);
+    };
+  }, [orientation, monthMarkers.length]);
+
+  const jumpHorizontal = (direction) => {
+    railRef.current?.scrollBy({
+      left: direction * Math.max(window.innerWidth * 0.72, 460),
+      behavior: "smooth",
+    });
+  };
+
+  const jumpToMonth = (monthKey) => {
+    railRef.current?.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({
+      behavior: "smooth",
+      inline: "center",
+      block: "nearest",
+    });
+  };
+
+  const renderToggle = () => (
+    <div className="flex items-center gap-1 rounded-full border bg-background/80 p-1 backdrop-blur">
+      <Button
+        type="button"
+        variant={preference === TIMELINE_ORIENTATION.AUTO ? "secondary" : "ghost"}
+        size="icon"
+        className="h-8 w-8 rounded-full"
+        onClick={() => setPreference(TIMELINE_ORIENTATION.AUTO)}
+        title="Automatic timeline layout"
+      >
+        <Monitor className="h-3.5 w-3.5" />
+      </Button>
+      <Button
+        type="button"
+        variant={preference === TIMELINE_ORIENTATION.HORIZONTAL ? "secondary" : "ghost"}
+        size="icon"
+        className="h-8 w-8 rounded-full"
+        onClick={() => setPreference(TIMELINE_ORIENTATION.HORIZONTAL)}
+        title="Horizontal timeline"
+      >
+        <Columns3 className="h-3.5 w-3.5" />
+      </Button>
+      <Button
+        type="button"
+        variant={preference === TIMELINE_ORIENTATION.VERTICAL ? "secondary" : "ghost"}
+        size="icon"
+        className="h-8 w-8 rounded-full"
+        onClick={() => setPreference(TIMELINE_ORIENTATION.VERTICAL)}
+        title="Vertical timeline"
+      >
+        <Rows3 className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+
+  if (orientation === TIMELINE_ORIENTATION.VERTICAL) {
+    return (
+      <section className="mx-auto w-full max-w-6xl px-4 pb-20 sm:px-6 lg:px-8">
+        <div className="mb-5 flex items-center justify-between gap-4">
+          <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Timeline layout</div>
+          {renderToggle()}
+        </div>
+
+        <div className="relative mx-auto max-w-5xl">
+          <div className="pointer-events-none absolute left-1/2 top-0 hidden h-full w-px -translate-x-1/2 bg-border md:block" />
+          <div
+            className="pointer-events-none absolute left-1/2 top-0 hidden w-px -translate-x-1/2 md:block"
+            style={{
+              height: `${progress}%`,
+              background: activeColor.line,
+              boxShadow: `0 0 14px ${activeColor.glow}`,
+            }}
+          />
+
+          <div className="space-y-14 md:space-y-20">
+            {events.map((event, index) => {
+              const date = new Date(event.occurred_at);
+              const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+              const monthIndex = monthMarkers.findIndex((month) => month.key === monthKey);
+              const color = getTimelineColor(date.getFullYear(), Math.max(monthIndex, 0));
+              const active = activeMonth === monthKey;
+              const above = index % 2 === 0;
+
+              return (
+                <div key={event.event_id} className="relative grid items-center md:grid-cols-[1fr_96px_1fr] md:gap-0" data-month={monthKey}>
+                  <div className={`${above ? "md:col-start-1 md:pr-10" : "md:col-start-3 md:pl-10"}`}>
+                    <TimelineCard
+                      event={event}
+                      above={above}
+                      active={active}
+                      color={color}
+                      onSelect={onSelectEvent}
+                      orientation={TIMELINE_ORIENTATION.VERTICAL}
+                    />
+                  </div>
+
+                  <div className="relative z-20 hidden min-h-[250px] md:flex md:items-center md:justify-center">
+                    <div className="absolute left-1/2 top-1/2 h-px w-12 -translate-y-1/2 bg-border" />
+                    <motion.div
+                      className="relative h-3.5 w-3.5 rounded-full border-2 bg-background"
+                      animate={{ scale: active ? 1.25 : 1 }}
+                      transition={{ duration: 0.2 }}
+                      style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }}
+                    />
+                  </div>
+
+                  <div className="mt-3 md:hidden">
+                    <div className="ml-4 h-8 w-px bg-border" />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="relative pb-16">
+      <div className="mb-5 flex items-center justify-between gap-4 px-5 sm:px-8 lg:px-12">
+        <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Timeline layout</div>
+        <div className="flex items-center gap-2">
+          {renderToggle()}
+          <Button variant="outline" size="icon" className="rounded-full" onClick={() => jumpHorizontal(-1)}>
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="icon" className="rounded-full" onClick={() => jumpHorizontal(1)}>
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div ref={railRef} className="scrollbar-hide flex h-[64vh] min-h-[560px] items-stretch gap-0 overflow-x-auto overflow-y-hidden px-[7vw] py-6 sm:px-[8vw]">
+        <div className="relative flex min-w-max items-center py-24">
+          <Progress value={progress} className="pointer-events-none absolute left-0 right-0 top-1/2 z-0 -translate-y-1/2">
+            <ProgressTrack className="h-[3px] bg-muted/90">
+              <ProgressIndicator className="h-full transition-none" style={{ background: activeColor.line, boxShadow: `0 0 12px ${activeColor.glow}` }} />
+            </ProgressTrack>
+          </Progress>
+
+          {events.map((event, index) => {
+            const date = new Date(event.occurred_at);
+            const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+            const monthIndex = monthMarkers.findIndex((month) => month.key === monthKey);
+            const color = getTimelineColor(date.getFullYear(), Math.max(monthIndex, 0));
+            const active = activeMonth === monthKey;
+            const above = index % 2 === 0;
+
+            return (
+              <div key={event.event_id} data-month={monthKey} className="relative flex h-[560px] w-[410px] shrink-0 items-center justify-center">
+                <div className={`relative z-10 ${above ? "mb-[260px]" : "mt-[260px]"}`}>
+                  <div
+                    aria-hidden="true"
+                    className={`pointer-events-none absolute left-1/2 h-[60px] w-px -translate-x-1/2 ${above ? "top-full" : "bottom-full"}`}
+                    style={{ background: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 10px ${color.glow}` : undefined }}
+                  />
+                  <TimelineCard
+                    event={event}
+                    above={above}
+                    active={active}
+                    color={color}
+                    onSelect={onSelectEvent}
+                    orientation={TIMELINE_ORIENTATION.HORIZONTAL}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-4 flex items-center justify-center gap-2 overflow-x-auto px-5 pb-1">
+        {monthMarkers.map((month, index) => {
+          const color = getTimelineColor(month.year, index);
+          const active = month.key === activeMonth;
+          return (
+            <button
+              key={month.key}
+              type="button"
+              onClick={() => jumpToMonth(month.key)}
+              className={`shrink-0 rounded-full border px-3 py-1.5 text-[11px] font-medium transition ${active ? "text-foreground shadow-sm" : "text-muted-foreground"}`}
+              style={{ borderColor: active ? color.line : color.glow, background: active ? color.glow : "transparent" }}
+            >
+              {month.label}
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/space/timeline/AdaptiveTimelineRail.jsx
+++ b/src/components/space/timeline/AdaptiveTimelineRail.jsx
@@ -62,7 +62,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
 
   const handleVerticalScroll = () => {
     if (orientation !== TIMELINE_ORIENTATION.VERTICAL) return;
-    const nodes = document.querySelectorAll("[data-month]");
+    const nodes = document.querySelectorAll("[data-timeline-event]");
     const readingLine = window.innerHeight * 0.42;
     let closest = null;
     let distance = Infinity;
@@ -90,7 +90,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
       window.removeEventListener("resize", onScroll);
       window.cancelAnimationFrame(frame);
     };
-  }, [orientation, events.length, monthMarkers.length]);
+  }, [orientation, events.length]);
 
   useEffect(() => {
     const rail = railRef.current;
@@ -131,7 +131,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
       return;
     }
 
-    document.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({ behavior: "smooth", block: "center" });
+    document.querySelector(`[data-timeline-event][data-month="${monthKey}"]`)?.scrollIntoView({ behavior: "smooth", block: "center" });
     onMonthChange(monthKey);
   };
 
@@ -149,13 +149,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
         const color = getTimelineColorForMonth(month.key, monthMarkers);
         const active = month.key === activeMonth;
         return (
-          <button
-            key={month.key}
-            type="button"
-            onClick={() => jumpToMonth(month.key)}
-            className={`shrink-0 rounded-full border px-3 py-1.5 text-[11px] font-medium transition ${active ? "text-foreground shadow-sm" : "text-muted-foreground"}`}
-            style={{ borderColor: active ? color.line : color.glow, background: active ? color.glow : "transparent" }}
-          >{month.label}</button>
+          <button key={month.key} type="button" onClick={() => jumpToMonth(month.key)} className={`shrink-0 rounded-full border px-3 py-1.5 text-[11px] font-medium transition ${active ? "text-foreground shadow-sm" : "text-muted-foreground"}`} style={{ borderColor: active ? color.line : color.glow, background: active ? color.glow : "transparent" }}>{month.label}</button>
         );
       })}
     </div>
@@ -186,38 +180,19 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
                 const monthIndex = monthMarkers.findIndex((month) => month.key === monthKey);
                 const color = getTimelineColorForMonth(monthKey, monthMarkers);
                 const active = activeMonth === monthKey;
-                const left = index % 2 === 0;
+                const cardOnLeft = index % 2 === 0;
                 const monthLabel = monthMarkers[monthIndex]?.label;
 
                 return (
-                  <div key={event.event_id} data-month={monthKey} className="relative md:grid md:min-h-[280px] md:grid-cols-[minmax(0,1fr)_minmax(220px,260px)_minmax(0,1fr)] md:items-center">
-                    <div className={left ? "md:col-start-1" : "md:col-start-3"}>
-                      <TimelineCard
-                        event={event}
-                        active={active}
-                        color={color}
-                        onSelect={onSelectEvent}
-                        orientation={TIMELINE_ORIENTATION.VERTICAL}
-                        monthIndex={Math.max(monthIndex, 0)}
-                      />
+                  <div key={event.event_id} data-timeline-event data-month={monthKey} className="relative md:grid md:min-h-[300px] md:grid-cols-[minmax(0,1fr)_220px_minmax(0,1fr)] md:items-center">
+                    <div className={cardOnLeft ? "md:col-start-1 md:pr-12" : "md:col-start-3 md:pl-12"}>
+                      <TimelineCard event={event} active={active} color={color} onSelect={onSelectEvent} orientation={TIMELINE_ORIENTATION.VERTICAL} monthIndex={Math.max(monthIndex, 0)} />
                     </div>
 
-                    <div className="relative hidden h-[280px] md:col-start-2 md:block">
-                      {left ? (
-                        <>
-                          <div className="absolute left-0 top-1/2 h-px w-1/2" style={{ background: active ? color.line : "hsl(var(--border))" }} />
-                          <div className="absolute right-0 top-1/2 h-px w-1/2" style={{ background: active ? color.line : "hsl(var(--border))" }} />
-                          <div className="absolute left-[-1px] top-1/2 h-px w-8 -translate-x-full" style={{ background: active ? color.line : "hsl(var(--border))" }} />
-                          <div className="absolute right-0 top-1/2 w-1/2 -translate-x-1/2 text-right text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}>{monthLabel}</div>
-                        </>
-                      ) : (
-                        <>
-                          <div className="absolute left-0 top-1/2 h-px w-1/2" style={{ background: active ? color.line : "hsl(var(--border))" }} />
-                          <div className="absolute right-0 top-1/2 h-px w-1/2" style={{ background: active ? color.line : "hsl(var(--border))" }} />
-                          <div className="absolute left-0 top-1/2 w-1/2 -translate-x-1/2 text-left text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}>{monthLabel}</div>
-                          <div className="absolute right-[-1px] top-1/2 h-px w-8 translate-x-full" style={{ background: active ? color.line : "hsl(var(--border))" }} />
-                        </>
-                      )}
+                    <div className="relative hidden h-[300px] md:col-start-2 md:block">
+                      <div className="absolute inset-0 flex items-center justify-center">
+                        <div className="text-center text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}>{monthLabel}</div>
+                      </div>
                     </div>
                   </div>
                 );

--- a/src/components/space/timeline/AdaptiveTimelineRail.jsx
+++ b/src/components/space/timeline/AdaptiveTimelineRail.jsx
@@ -171,7 +171,17 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
 
           <div className="relative mx-auto max-w-5xl">
             <div className="pointer-events-none absolute left-1/2 top-0 hidden h-full w-px -translate-x-1/2 bg-border md:block" />
-            <div className="pointer-events-none absolute left-1/2 top-0 hidden w-px -translate-x-1/2 md:block" style={{ height: `${progress}%`, background: activeColor.line, boxShadow: `0 0 14px ${activeColor.glow}` }} />
+            <Progress
+              value={progress}
+              className="pointer-events-none absolute left-1/2 top-0 hidden h-full w-px -translate-x-1/2 md:block [&_[data-slot=progress-track]]:h-full [&_[data-slot=progress-indicator]]:w-px"
+            >
+              <ProgressTrack className="h-full w-px bg-transparent">
+                <ProgressIndicator
+                  className="h-full w-px origin-top transition-[height,background-color,box-shadow] duration-1000 ease-out"
+                  style={{ background: activeColor.line, boxShadow: `0 0 14px ${activeColor.glow}` }}
+                />
+              </ProgressTrack>
+            </Progress>
 
             <div className="space-y-28 md:space-y-32">
               {events.map((event, index) => {
@@ -185,13 +195,13 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
 
                 return (
                   <div key={event.event_id} data-timeline-event data-month={monthKey} className="relative md:grid md:min-h-[300px] md:grid-cols-[minmax(0,1fr)_220px_minmax(0,1fr)] md:items-center">
-                    <div className={cardOnLeft ? "md:col-start-1 md:pr-12" : "md:col-start-3 md:pl-12"}>
+                    <div className={cardOnLeft ? "md:col-start-1" : "md:col-start-3"}>
                       <TimelineCard event={event} active={active} color={color} onSelect={onSelectEvent} orientation={TIMELINE_ORIENTATION.VERTICAL} monthIndex={Math.max(monthIndex, 0)} />
                     </div>
 
-                    <div className="relative hidden h-[300px] md:col-start-2 md:block">
-                      <div className="absolute inset-0 flex items-center justify-center">
-                        <div className="text-center text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}>{monthLabel}</div>
+                    <div className="relative hidden h-[300px] md:col-start-2 md:flex md:items-center md:justify-center">
+                      <div className="w-[120px] text-center text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}>
+                        {monthLabel}
                       </div>
                     </div>
                   </div>

--- a/src/components/space/timeline/AdaptiveTimelineRail.jsx
+++ b/src/components/space/timeline/AdaptiveTimelineRail.jsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { motion } from "framer-motion";
 import { ChevronLeft, ChevronRight, Monitor, Rows3, Columns3 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -61,7 +60,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
     if (closest) onMonthChange(closest);
   };
 
-  const scrollToActiveVerticalMonth = () => {
+  const handleVerticalScroll = () => {
     if (orientation !== TIMELINE_ORIENTATION.VERTICAL) return;
     const nodes = document.querySelectorAll("[data-month]");
     const readingLine = window.innerHeight * 0.42;
@@ -69,6 +68,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
     let distance = Infinity;
     nodes.forEach((node) => {
       const rect = node.getBoundingClientRect();
+      if (rect.bottom < 80 || rect.top > window.innerHeight) return;
       const nodeCenter = rect.top + rect.height / 2;
       const diff = Math.abs(nodeCenter - readingLine);
       if (diff < distance) {
@@ -81,7 +81,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
 
   useEffect(() => {
     if (orientation !== TIMELINE_ORIENTATION.VERTICAL) return undefined;
-    const onScroll = () => scrollToActiveVerticalMonth();
+    const onScroll = () => handleVerticalScroll();
     window.addEventListener("scroll", onScroll, { passive: true });
     window.addEventListener("resize", onScroll);
     const frame = window.requestAnimationFrame(onScroll);
@@ -131,22 +131,15 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
       return;
     }
 
-    const target = document.querySelector(`[data-month="${monthKey}"]`);
-    target?.scrollIntoView({ behavior: "smooth", block: "center" });
+    document.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({ behavior: "smooth", block: "center" });
     onMonthChange(monthKey);
   };
 
   const renderToggle = () => (
     <div className="flex items-center gap-1 rounded-full border bg-background/80 p-1 backdrop-blur">
-      <Button type="button" variant={preference === TIMELINE_ORIENTATION.AUTO ? "secondary" : "ghost"} size="icon" className="h-8 w-8 rounded-full" onClick={() => setPreference(TIMELINE_ORIENTATION.AUTO)} title="Automatic timeline layout">
-        <Monitor className="h-3.5 w-3.5" />
-      </Button>
-      <Button type="button" variant={preference === TIMELINE_ORIENTATION.HORIZONTAL ? "secondary" : "ghost"} size="icon" className="h-8 w-8 rounded-full" onClick={() => setPreference(TIMELINE_ORIENTATION.HORIZONTAL)} title="Horizontal timeline">
-        <Columns3 className="h-3.5 w-3.5" />
-      </Button>
-      <Button type="button" variant={preference === TIMELINE_ORIENTATION.VERTICAL ? "secondary" : "ghost"} size="icon" className="h-8 w-8 rounded-full" onClick={() => setPreference(TIMELINE_ORIENTATION.VERTICAL)} title="Vertical timeline">
-        <Rows3 className="h-3.5 w-3.5" />
-      </Button>
+      <Button type="button" variant={preference === TIMELINE_ORIENTATION.AUTO ? "secondary" : "ghost"} size="icon" className="h-8 w-8 rounded-full" onClick={() => setPreference(TIMELINE_ORIENTATION.AUTO)} title="Automatic timeline layout"><Monitor className="h-3.5 w-3.5" /></Button>
+      <Button type="button" variant={preference === TIMELINE_ORIENTATION.HORIZONTAL ? "secondary" : "ghost"} size="icon" className="h-8 w-8 rounded-full" onClick={() => setPreference(TIMELINE_ORIENTATION.HORIZONTAL)} title="Horizontal timeline"><Columns3 className="h-3.5 w-3.5" /></Button>
+      <Button type="button" variant={preference === TIMELINE_ORIENTATION.VERTICAL ? "secondary" : "ghost"} size="icon" className="h-8 w-8 rounded-full" onClick={() => setPreference(TIMELINE_ORIENTATION.VERTICAL)} title="Vertical timeline"><Rows3 className="h-3.5 w-3.5" /></Button>
     </div>
   );
 
@@ -162,9 +155,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
             onClick={() => jumpToMonth(month.key)}
             className={`shrink-0 rounded-full border px-3 py-1.5 text-[11px] font-medium transition ${active ? "text-foreground shadow-sm" : "text-muted-foreground"}`}
             style={{ borderColor: active ? color.line : color.glow, background: active ? color.glow : "transparent" }}
-          >
-            {month.label}
-          </button>
+          >{month.label}</button>
         );
       })}
     </div>
@@ -172,24 +163,21 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
 
   if (orientation === TIMELINE_ORIENTATION.VERTICAL) {
     return (
-      <section className="mx-auto w-full max-w-7xl pb-20 px-4 sm:px-6 lg:px-8">
+      <section className="mx-auto w-full max-w-7xl px-4 pb-20 sm:px-6 lg:px-8">
         <div className="mb-5 flex items-center justify-between gap-4">
           <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Timeline layout</div>
           {renderToggle()}
         </div>
 
-        <div className="relative md:pl-44">
-          <aside className="md:sticky md:top-24 md:z-20 md:float-left md:ml-[-11rem] md:w-36">
+        <div className="relative md:pl-40">
+          <aside className="md:sticky md:top-24 md:z-20 md:float-left md:ml-[-10rem] md:w-32">
             <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">Months</div>
             <div className="mt-3 max-h-[70vh] overflow-y-auto pr-1">{monthFilter(true)}</div>
           </aside>
 
           <div className="relative mx-auto max-w-5xl">
             <div className="pointer-events-none absolute left-1/2 top-0 hidden h-full w-px -translate-x-1/2 bg-border md:block" />
-            <div
-              className="pointer-events-none absolute left-1/2 top-0 hidden w-px -translate-x-1/2 md:block"
-              style={{ height: `${progress}%`, background: activeColor.line, boxShadow: `0 0 14px ${activeColor.glow}` }}
-            />
+            <div className="pointer-events-none absolute left-1/2 top-0 hidden w-px -translate-x-1/2 md:block" style={{ height: `${progress}%`, background: activeColor.line, boxShadow: `0 0 14px ${activeColor.glow}` }} />
 
             <div className="space-y-28 md:space-y-32">
               {events.map((event, index) => {
@@ -202,8 +190,8 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
                 const monthLabel = monthMarkers[monthIndex]?.label;
 
                 return (
-                  <div key={event.event_id} data-month={monthKey} className="relative min-h-[300px] md:grid md:grid-cols-[minmax(0,1fr)_220px_minmax(0,1fr)] md:items-center">
-                    <div className={left ? "md:col-start-1 md:pr-14" : "md:col-start-3 md:pl-14"}>
+                  <div key={event.event_id} data-month={monthKey} className="relative md:grid md:min-h-[280px] md:grid-cols-[minmax(0,1fr)_minmax(220px,260px)_minmax(0,1fr)] md:items-center">
+                    <div className={left ? "md:col-start-1" : "md:col-start-3"}>
                       <TimelineCard
                         event={event}
                         active={active}
@@ -214,27 +202,22 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
                       />
                     </div>
 
-                    <div className="relative hidden min-h-[300px] md:col-start-2 md:block">
-                      <div className="absolute left-1/2 top-1/2 h-px w-40 -translate-y-1/2" style={{ background: "transparent" }} />
-
-                      <div
-                        className={`absolute top-1/2 -translate-y-1/2 ${left ? "right-0" : "left-0"}`}
-                        style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}
-                      >
-                        <div className="whitespace-nowrap text-[11px] font-semibold uppercase tracking-[0.16em]">{monthLabel}</div>
-                      </div>
-
-                      <div
-                        className={`absolute top-1/2 h-px -translate-y-1/2 ${left ? "right-[72px] left-0" : "left-[72px] right-0"}`}
-                        style={{ background: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 8px ${color.glow}` : undefined }}
-                      />
-
-                      <motion.div
-                        className="absolute left-1/2 top-1/2 z-20 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 bg-background"
-                        animate={{ scale: active ? 1.2 : 1 }}
-                        transition={{ duration: 0.2 }}
-                        style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }}
-                      />
+                    <div className="relative hidden h-[280px] md:col-start-2 md:block">
+                      {left ? (
+                        <>
+                          <div className="absolute left-0 top-1/2 h-px w-1/2" style={{ background: active ? color.line : "hsl(var(--border))" }} />
+                          <div className="absolute right-0 top-1/2 h-px w-1/2" style={{ background: active ? color.line : "hsl(var(--border))" }} />
+                          <div className="absolute left-[-1px] top-1/2 h-px w-8 -translate-x-full" style={{ background: active ? color.line : "hsl(var(--border))" }} />
+                          <div className="absolute right-0 top-1/2 w-1/2 -translate-x-1/2 text-right text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}>{monthLabel}</div>
+                        </>
+                      ) : (
+                        <>
+                          <div className="absolute left-0 top-1/2 h-px w-1/2" style={{ background: active ? color.line : "hsl(var(--border))" }} />
+                          <div className="absolute right-0 top-1/2 h-px w-1/2" style={{ background: active ? color.line : "hsl(var(--border))" }} />
+                          <div className="absolute left-0 top-1/2 w-1/2 -translate-x-1/2 text-left text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}>{monthLabel}</div>
+                          <div className="absolute right-[-1px] top-1/2 h-px w-8 translate-x-full" style={{ background: active ? color.line : "hsl(var(--border))" }} />
+                        </>
+                      )}
                     </div>
                   </div>
                 );
@@ -256,9 +239,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
       <div ref={railRef} className="scrollbar-hide overflow-x-auto overflow-y-hidden px-[7vw] py-8 sm:px-[8vw]">
         <div className="relative mx-auto flex min-w-max items-center">
           <div className="pointer-events-none absolute left-0 right-0 top-[340px] z-0 h-[3px] rounded-full bg-muted/90" />
-          <Progress value={progress} className="pointer-events-none absolute left-0 right-0 top-[340px] z-0">
-            <ProgressTrack className="h-[3px] bg-transparent"><ProgressIndicator className="h-full transition-none" style={{ background: activeColor.line, boxShadow: `0 0 12px ${activeColor.glow}` }} /></ProgressTrack>
-          </Progress>
+          <Progress value={progress} className="pointer-events-none absolute left-0 right-0 top-[340px] z-0"><ProgressTrack className="h-[3px] bg-transparent"><ProgressIndicator className="h-full transition-none" style={{ background: activeColor.line, boxShadow: `0 0 12px ${activeColor.glow}` }} /></ProgressTrack></Progress>
 
           {events.map((event, index) => {
             const date = new Date(event.occurred_at);
@@ -273,16 +254,11 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
               <div key={event.event_id} data-month={monthKey} className="relative w-[460px] shrink-0 px-5">
                 <div className="relative h-[720px]">
                   <div className={`absolute left-1/2 z-10 w-[390px] -translate-x-1/2 ${above ? "bottom-[390px]" : "top-[390px]"}`}>
-                    <div className={`relative ${above ? "pb-12" : "pt-12"}`}>
-                      <div className={`absolute left-1/2 z-20 -translate-x-1/2 whitespace-nowrap text-[11px] font-semibold uppercase tracking-[0.16em] ${above ? "bottom-2" : "top-2"}`} style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}>
-                        {monthLabel}
-                      </div>
-                      <TimelineCard event={event} active={active} color={color} onSelect={onSelectEvent} orientation={TIMELINE_ORIENTATION.HORIZONTAL} monthIndex={Math.max(monthIndex, 0)} />
-                    </div>
+                    <TimelineCard event={event} active={active} color={color} onSelect={onSelectEvent} orientation={TIMELINE_ORIENTATION.HORIZONTAL} monthIndex={Math.max(monthIndex, 0)} />
                   </div>
-
                   <div className="absolute left-1/2 top-[340px] z-20 h-px w-16 -translate-x-1/2" style={{ background: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 8px ${color.glow}` : undefined }} />
                   <div className="absolute left-1/2 top-[340px] z-20 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 bg-background" style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }} />
+                  <div className={`absolute left-1/2 z-20 -translate-x-1/2 whitespace-nowrap text-[11px] font-semibold uppercase tracking-[0.16em] ${above ? "bottom-[346px]" : "top-[346px]"}`} style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}>{monthLabel}</div>
                 </div>
               </div>
             );

--- a/src/components/space/timeline/AdaptiveTimelineRail.jsx
+++ b/src/components/space/timeline/AdaptiveTimelineRail.jsx
@@ -22,6 +22,8 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
   const [preference, setPreference] = useState(TIMELINE_ORIENTATION.AUTO);
   const [width, setWidth] = useState(1440);
   const railRef = useRef(null);
+  const verticalRef = useRef(null);
+  const verticalScrollFrame = useRef(null);
 
   useEffect(() => {
     const update = () => setWidth(window.innerWidth);
@@ -58,8 +60,61 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
         closest = node.dataset.month;
       }
     });
-    if (closest) onMonthChange(closest);
+    if (closest && closest !== activeMonth) onMonthChange(closest);
   };
+
+  const updateVerticalActiveMonth = () => {
+    if (orientation !== TIMELINE_ORIENTATION.VERTICAL) return;
+    const container = verticalRef.current;
+    if (!container) return;
+
+    const nodes = container.querySelectorAll("[data-month]");
+    if (!nodes.length) return;
+
+    // The event closest to the visual reading line becomes the active month.
+    // This keeps the filter, rail progress and card highlight in sync with
+    // ordinary page scrolling, not only with filter clicks.
+    const readingLine = window.innerHeight * 0.42;
+    let closest = null;
+    let distance = Infinity;
+
+    nodes.forEach((node) => {
+      const rect = node.getBoundingClientRect();
+      const center = rect.top + rect.height / 2;
+      const diff = Math.abs(center - readingLine);
+      if (diff < distance) {
+        distance = diff;
+        closest = node.dataset.month;
+      }
+    });
+
+    if (closest && closest !== activeMonth) onMonthChange(closest);
+  };
+
+  useEffect(() => {
+    if (orientation !== TIMELINE_ORIENTATION.VERTICAL) return undefined;
+
+    const onScroll = () => {
+      if (verticalScrollFrame.current) return;
+      verticalScrollFrame.current = window.requestAnimationFrame(() => {
+        verticalScrollFrame.current = null;
+        updateVerticalActiveMonth();
+      });
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    onScroll();
+
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      if (verticalScrollFrame.current) {
+        window.cancelAnimationFrame(verticalScrollFrame.current);
+        verticalScrollFrame.current = null;
+      }
+    };
+  }, [orientation, events.length, monthMarkers.length]);
 
   useEffect(() => {
     const rail = railRef.current;
@@ -81,7 +136,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
       rail.removeEventListener("wheel", onWheel);
       rail.removeEventListener("scroll", handleScroll);
     };
-  }, [orientation, monthMarkers.length]);
+  }, [orientation, monthMarkers.length, activeMonth]);
 
   const jumpHorizontal = (direction) => {
     railRef.current?.scrollBy({
@@ -100,8 +155,10 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
       return;
     }
 
-    const target = document.querySelector(`[data-month="${monthKey}"]`);
-    target?.scrollIntoView({ behavior: "smooth", block: "center" });
+    verticalRef.current?.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+    });
     onMonthChange(monthKey);
   };
 
@@ -141,19 +198,19 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
 
   if (orientation === TIMELINE_ORIENTATION.VERTICAL) {
     return (
-      <section className="mx-auto w-full max-w-7xl pb-20 px-4 sm:px-6 lg:px-8">
+      <section className="mx-auto w-full max-w-7xl px-4 pb-20 sm:px-6 lg:px-8">
         <div className="mb-5 flex items-center justify-between gap-4">
           <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Timeline layout</div>
           {renderToggle()}
         </div>
 
-        <div className="relative md:pl-44">
-          <aside className="md:sticky md:top-24 md:z-20 md:float-left md:ml-[-11rem] md:w-36">
+        <div className="grid items-start gap-8 md:grid-cols-[150px_minmax(0,1fr)]">
+          <aside className="md:sticky md:top-24 md:z-30 md:self-start">
             <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">Months</div>
-            <div className="mt-3 max-h-[70vh] overflow-y-auto pr-1">{monthFilter(true)}</div>
+            <div className="mt-3 max-h-[calc(100vh-8rem)] overflow-y-auto pr-1">{monthFilter(true)}</div>
           </aside>
 
-          <div className="relative mx-auto max-w-5xl">
+          <div ref={verticalRef} className="relative min-w-0">
             <div className="pointer-events-none absolute left-1/2 top-0 hidden h-full w-px -translate-x-1/2 bg-border md:block" />
             <div
               className="pointer-events-none absolute left-1/2 top-0 hidden w-px -translate-x-1/2 md:block"
@@ -172,7 +229,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
 
                 return (
                   <div key={event.event_id} data-month={monthKey} className="relative min-h-[300px] md:grid md:grid-cols-[minmax(0,1fr)_220px_minmax(0,1fr)] md:items-center">
-                    <div className={left ? "md:col-start-1 md:pr-14" : "md:col-start-3 md:pl-14"}>
+                    <div className={left ? "md:col-start-1 md:pr-16" : "md:col-start-3 md:pl-16"}>
                       <TimelineCard
                         event={event}
                         active={active}
@@ -184,17 +241,9 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
                     </div>
 
                     <div className="relative hidden min-h-[300px] md:col-start-2 md:block">
+                      {/* The branch always starts at the spine marker and points toward the card. */}
                       <div
-                        className={`absolute top-1/2 -translate-y-1/2 ${left ? "right-0 mr-10" : "left-0 ml-10"}`}
-                        style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}
-                      >
-                        <div className="whitespace-nowrap text-[11px] font-semibold uppercase tracking-[0.16em]">
-                          {monthLabel}
-                        </div>
-                      </div>
-
-                      <div
-                        className={`absolute top-1/2 h-px -translate-y-1/2 ${left ? "left-0 right-1/2 ml-2 mr-2" : "left-1/2 right-0 ml-2 mr-2"}`}
+                        className={`absolute top-1/2 h-px -translate-y-1/2 ${left ? "left-0 w-1/2" : "left-1/2 w-1/2"}`}
                         style={{ background: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 8px ${color.glow}` : undefined }}
                       />
 
@@ -204,6 +253,22 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
                         transition={{ duration: 0.2 }}
                         style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }}
                       />
+
+                      {/* Date sits in the empty space beside the card, with a deliberate gap from the spine. */}
+                      <div
+                        className={`absolute top-1/2 z-30 -translate-y-1/2 bg-background/95 px-2 ${left ? "right-1/2 mr-3" : "left-1/2 ml-3"}`}
+                      >
+                        <div
+                          className="whitespace-nowrap text-[11px] font-semibold uppercase tracking-[0.16em]"
+                          style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}
+                        >
+                          {monthLabel}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="md:hidden">
+                      <div className="ml-4 mt-4 h-8 w-px" style={{ background: color.line }} />
                     </div>
                   </div>
                 );

--- a/src/components/space/timeline/AdaptiveTimelineRail.jsx
+++ b/src/components/space/timeline/AdaptiveTimelineRail.jsx
@@ -22,8 +22,6 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
   const [preference, setPreference] = useState(TIMELINE_ORIENTATION.AUTO);
   const [width, setWidth] = useState(1440);
   const railRef = useRef(null);
-  const verticalRef = useRef(null);
-  const verticalScrollFrame = useRef(null);
 
   useEffect(() => {
     const update = () => setWidth(window.innerWidth);
@@ -44,7 +42,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
     ? getTimelineColorForMonth(activeMonth, monthMarkers)
     : getTimelineColor(0, 0);
 
-  const handleScroll = () => {
+  const handleHorizontalScroll = () => {
     if (orientation !== TIMELINE_ORIENTATION.HORIZONTAL) return;
     const rail = railRef.current;
     if (!rail) return;
@@ -60,59 +58,37 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
         closest = node.dataset.month;
       }
     });
-    if (closest && closest !== activeMonth) onMonthChange(closest);
+    if (closest) onMonthChange(closest);
   };
 
-  const updateVerticalActiveMonth = () => {
+  const scrollToActiveVerticalMonth = () => {
     if (orientation !== TIMELINE_ORIENTATION.VERTICAL) return;
-    const container = verticalRef.current;
-    if (!container) return;
-
-    const nodes = container.querySelectorAll("[data-month]");
-    if (!nodes.length) return;
-
-    // The event closest to the visual reading line becomes the active month.
-    // This keeps the filter, rail progress and card highlight in sync with
-    // ordinary page scrolling, not only with filter clicks.
+    const nodes = document.querySelectorAll("[data-month]");
     const readingLine = window.innerHeight * 0.42;
     let closest = null;
     let distance = Infinity;
-
     nodes.forEach((node) => {
       const rect = node.getBoundingClientRect();
-      const center = rect.top + rect.height / 2;
-      const diff = Math.abs(center - readingLine);
+      const nodeCenter = rect.top + rect.height / 2;
+      const diff = Math.abs(nodeCenter - readingLine);
       if (diff < distance) {
         distance = diff;
         closest = node.dataset.month;
       }
     });
-
-    if (closest && closest !== activeMonth) onMonthChange(closest);
+    if (closest) onMonthChange(closest);
   };
 
   useEffect(() => {
     if (orientation !== TIMELINE_ORIENTATION.VERTICAL) return undefined;
-
-    const onScroll = () => {
-      if (verticalScrollFrame.current) return;
-      verticalScrollFrame.current = window.requestAnimationFrame(() => {
-        verticalScrollFrame.current = null;
-        updateVerticalActiveMonth();
-      });
-    };
-
+    const onScroll = () => scrollToActiveVerticalMonth();
     window.addEventListener("scroll", onScroll, { passive: true });
     window.addEventListener("resize", onScroll);
-    onScroll();
-
+    const frame = window.requestAnimationFrame(onScroll);
     return () => {
       window.removeEventListener("scroll", onScroll);
       window.removeEventListener("resize", onScroll);
-      if (verticalScrollFrame.current) {
-        window.cancelAnimationFrame(verticalScrollFrame.current);
-        verticalScrollFrame.current = null;
-      }
+      window.cancelAnimationFrame(frame);
     };
   }, [orientation, events.length, monthMarkers.length]);
 
@@ -130,13 +106,13 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
     };
 
     rail.addEventListener("wheel", onWheel, { passive: false });
-    rail.addEventListener("scroll", handleScroll, { passive: true });
-    handleScroll();
+    rail.addEventListener("scroll", handleHorizontalScroll, { passive: true });
+    handleHorizontalScroll();
     return () => {
       rail.removeEventListener("wheel", onWheel);
-      rail.removeEventListener("scroll", handleScroll);
+      rail.removeEventListener("scroll", handleHorizontalScroll);
     };
-  }, [orientation, monthMarkers.length, activeMonth]);
+  }, [orientation, monthMarkers.length]);
 
   const jumpHorizontal = (direction) => {
     railRef.current?.scrollBy({
@@ -155,10 +131,8 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
       return;
     }
 
-    verticalRef.current?.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({
-      behavior: "smooth",
-      block: "center",
-    });
+    const target = document.querySelector(`[data-month="${monthKey}"]`);
+    target?.scrollIntoView({ behavior: "smooth", block: "center" });
     onMonthChange(monthKey);
   };
 
@@ -198,19 +172,19 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
 
   if (orientation === TIMELINE_ORIENTATION.VERTICAL) {
     return (
-      <section className="mx-auto w-full max-w-7xl px-4 pb-20 sm:px-6 lg:px-8">
+      <section className="mx-auto w-full max-w-7xl pb-20 px-4 sm:px-6 lg:px-8">
         <div className="mb-5 flex items-center justify-between gap-4">
           <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Timeline layout</div>
           {renderToggle()}
         </div>
 
-        <div className="grid items-start gap-8 md:grid-cols-[150px_minmax(0,1fr)]">
-          <aside className="md:sticky md:top-24 md:z-30 md:self-start">
+        <div className="relative md:pl-44">
+          <aside className="md:sticky md:top-24 md:z-20 md:float-left md:ml-[-11rem] md:w-36">
             <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">Months</div>
-            <div className="mt-3 max-h-[calc(100vh-8rem)] overflow-y-auto pr-1">{monthFilter(true)}</div>
+            <div className="mt-3 max-h-[70vh] overflow-y-auto pr-1">{monthFilter(true)}</div>
           </aside>
 
-          <div ref={verticalRef} className="relative min-w-0">
+          <div className="relative mx-auto max-w-5xl">
             <div className="pointer-events-none absolute left-1/2 top-0 hidden h-full w-px -translate-x-1/2 bg-border md:block" />
             <div
               className="pointer-events-none absolute left-1/2 top-0 hidden w-px -translate-x-1/2 md:block"
@@ -229,7 +203,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
 
                 return (
                   <div key={event.event_id} data-month={monthKey} className="relative min-h-[300px] md:grid md:grid-cols-[minmax(0,1fr)_220px_minmax(0,1fr)] md:items-center">
-                    <div className={left ? "md:col-start-1 md:pr-16" : "md:col-start-3 md:pl-16"}>
+                    <div className={left ? "md:col-start-1 md:pr-14" : "md:col-start-3 md:pl-14"}>
                       <TimelineCard
                         event={event}
                         active={active}
@@ -241,9 +215,17 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
                     </div>
 
                     <div className="relative hidden min-h-[300px] md:col-start-2 md:block">
-                      {/* The branch always starts at the spine marker and points toward the card. */}
+                      <div className="absolute left-1/2 top-1/2 h-px w-40 -translate-y-1/2" style={{ background: "transparent" }} />
+
                       <div
-                        className={`absolute top-1/2 h-px -translate-y-1/2 ${left ? "left-0 w-1/2" : "left-1/2 w-1/2"}`}
+                        className={`absolute top-1/2 -translate-y-1/2 ${left ? "right-0" : "left-0"}`}
+                        style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}
+                      >
+                        <div className="whitespace-nowrap text-[11px] font-semibold uppercase tracking-[0.16em]">{monthLabel}</div>
+                      </div>
+
+                      <div
+                        className={`absolute top-1/2 h-px -translate-y-1/2 ${left ? "right-[72px] left-0" : "left-[72px] right-0"}`}
                         style={{ background: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 8px ${color.glow}` : undefined }}
                       />
 
@@ -253,22 +235,6 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
                         transition={{ duration: 0.2 }}
                         style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }}
                       />
-
-                      {/* Date sits in the empty space beside the card, with a deliberate gap from the spine. */}
-                      <div
-                        className={`absolute top-1/2 z-30 -translate-y-1/2 bg-background/95 px-2 ${left ? "right-1/2 mr-3" : "left-1/2 ml-3"}`}
-                      >
-                        <div
-                          className="whitespace-nowrap text-[11px] font-semibold uppercase tracking-[0.16em]"
-                          style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}
-                        >
-                          {monthLabel}
-                        </div>
-                      </div>
-                    </div>
-
-                    <div className="md:hidden">
-                      <div className="ml-4 mt-4 h-8 w-px" style={{ background: color.line }} />
                     </div>
                   </div>
                 );
@@ -315,14 +281,8 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
                     </div>
                   </div>
 
-                  <div
-                    className="absolute left-1/2 top-[340px] z-20 h-px w-16 -translate-x-1/2"
-                    style={{ background: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 8px ${color.glow}` : undefined }}
-                  />
-                  <div
-                    className="absolute left-1/2 top-[340px] z-20 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 bg-background"
-                    style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }}
-                  />
+                  <div className="absolute left-1/2 top-[340px] z-20 h-px w-16 -translate-x-1/2" style={{ background: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 8px ${color.glow}` : undefined }} />
+                  <div className="absolute left-1/2 top-[340px] z-20 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 bg-background" style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }} />
                 </div>
               </div>
             );

--- a/src/components/space/timeline/AdaptiveTimelineRail.jsx
+++ b/src/components/space/timeline/AdaptiveTimelineRail.jsx
@@ -91,11 +91,20 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
   };
 
   const jumpToMonth = (monthKey) => {
-    railRef.current?.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({
+    if (orientation === TIMELINE_ORIENTATION.HORIZONTAL) {
+      railRef.current?.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({
+        behavior: "smooth",
+        inline: "center",
+        block: "nearest",
+      });
+      return;
+    }
+
+    document.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({
       behavior: "smooth",
-      inline: "center",
-      block: "nearest",
+      block: "center",
     });
+    onMonthChange(monthKey);
   };
 
   const renderToggle = () => (
@@ -133,67 +142,99 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
     </div>
   );
 
+  const monthFilter = (
+    <div className="flex gap-2 overflow-x-auto pb-1">
+      {monthMarkers.map((month) => {
+        const color = getTimelineColorForMonth(month.key, monthMarkers);
+        const active = month.key === activeMonth;
+        return (
+          <button
+            key={month.key}
+            type="button"
+            onClick={() => jumpToMonth(month.key)}
+            className={`shrink-0 rounded-full border px-3 py-1.5 text-[11px] font-medium transition ${active ? "text-foreground shadow-sm" : "text-muted-foreground"}`}
+            style={{
+              borderColor: active ? color.line : color.glow,
+              background: active ? color.glow : "transparent",
+            }}
+          >
+            {month.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+
   if (orientation === TIMELINE_ORIENTATION.VERTICAL) {
     return (
-      <section className="mx-auto w-full max-w-6xl px-4 pb-20 sm:px-6 lg:px-8">
+      <section className="mx-auto w-full max-w-6xl pb-20 px-4 sm:px-6 lg:px-8">
         <div className="mb-5 flex items-center justify-between gap-4">
           <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Timeline layout</div>
           {renderToggle()}
         </div>
 
-        <div className="relative mx-auto max-w-5xl">
-          <div className="pointer-events-none absolute left-1/2 top-0 hidden h-full w-px -translate-x-1/2 bg-border md:block" />
-          <div
-            className="pointer-events-none absolute left-1/2 top-0 hidden w-px -translate-x-1/2 md:block"
-            style={{
-              height: `${progress}%`,
-              background: activeColor.line,
-              boxShadow: `0 0 14px ${activeColor.glow}`,
-            }}
-          />
+        <div className="relative md:pl-28">
+          <aside className="mb-6 md:sticky md:top-24 md:float-left md:ml-[-7rem] md:w-24">
+            <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">Months</div>
+            <div className="mt-3 max-h-[70vh] overflow-y-auto pr-1">
+              <div className="flex gap-2 overflow-x-auto md:flex-col md:overflow-x-visible">{monthFilter}</div>
+            </div>
+          </aside>
 
-          <div className="space-y-14 md:space-y-20">
-            {events.map((event, index) => {
-              const date = new Date(event.occurred_at);
-              const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
-              const monthIndex = monthMarkers.findIndex((month) => month.key === monthKey);
-              const color = getTimelineColorForMonth(monthKey, monthMarkers);
-              const active = activeMonth === monthKey;
-              const above = index % 2 === 0;
+          <div className="relative mx-auto max-w-5xl">
+            <div className="pointer-events-none absolute left-1/2 top-0 hidden h-full w-px -translate-x-1/2 bg-border md:block" />
+            <div
+              className="pointer-events-none absolute left-1/2 top-0 hidden w-px -translate-x-1/2 md:block"
+              style={{
+                height: `${progress}%`,
+                background: activeColor.line,
+                boxShadow: `0 0 14px ${activeColor.glow}`,
+              }}
+            />
 
-              return (
-                <div key={event.event_id} className="relative grid items-center md:grid-cols-[1fr_96px_1fr] md:gap-0" data-month={monthKey}>
-                  <div className={`${above ? "md:col-start-1 md:pr-10" : "md:col-start-3 md:pl-10"}`}>
-                    <TimelineCard
-                      event={event}
-                      above={above}
-                      active={active}
-                      color={color}
-                      onSelect={onSelectEvent}
-                      orientation={TIMELINE_ORIENTATION.VERTICAL}
-                      monthIndex={Math.max(monthIndex, 0)}
-                    />
+            <div className="space-y-14 md:space-y-20">
+              {events.map((event, index) => {
+                const date = new Date(event.occurred_at);
+                const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+                const monthIndex = monthMarkers.findIndex((month) => month.key === monthKey);
+                const color = getTimelineColorForMonth(monthKey, monthMarkers);
+                const active = activeMonth === monthKey;
+                const above = index % 2 === 0;
+
+                return (
+                  <div key={event.event_id} className="relative grid items-center md:grid-cols-[1fr_96px_1fr] md:gap-0" data-month={monthKey}>
+                    <div className={`${above ? "md:col-start-1 md:pr-10" : "md:col-start-3 md:pl-10"}`}>
+                      <TimelineCard
+                        event={event}
+                        above={above}
+                        active={active}
+                        color={color}
+                        onSelect={onSelectEvent}
+                        orientation={TIMELINE_ORIENTATION.VERTICAL}
+                        monthIndex={Math.max(monthIndex, 0)}
+                      />
+                    </div>
+
+                    <div className="relative z-20 hidden min-h-[250px] md:flex md:items-center md:justify-center">
+                      <div
+                        className="absolute left-1/2 top-1/2 h-px w-12 -translate-y-1/2"
+                        style={{ background: active ? color.line : "hsl(var(--border))" }}
+                      />
+                      <motion.div
+                        className="relative h-3.5 w-3.5 rounded-full border-2 bg-background"
+                        animate={{ scale: active ? 1.25 : 1 }}
+                        transition={{ duration: 0.2 }}
+                        style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }}
+                      />
+                    </div>
+
+                    <div className="mt-3 md:hidden">
+                      <div className="ml-4 h-8 w-px bg-border" />
+                    </div>
                   </div>
-
-                  <div className="relative z-20 hidden min-h-[250px] md:flex md:items-center md:justify-center">
-                    <div
-                      className="absolute left-1/2 top-1/2 h-px w-12 -translate-y-1/2"
-                      style={{ background: active ? color.line : "hsl(var(--border))" }}
-                    />
-                    <motion.div
-                      className="relative h-3.5 w-3.5 rounded-full border-2 bg-background"
-                      animate={{ scale: active ? 1.25 : 1 }}
-                      transition={{ duration: 0.2 }}
-                      style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }}
-                    />
-                  </div>
-
-                  <div className="mt-3 md:hidden">
-                    <div className="ml-4 h-8 w-px bg-border" />
-                  </div>
-                </div>
-              );
-            })}
+                );
+              })}
+            </div>
           </div>
         </div>
       </section>
@@ -236,21 +277,19 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
             const above = index % 2 === 0;
 
             return (
-              <div key={event.event_id} data-month={monthKey} className="relative w-[390px] shrink-0 px-5">
-                <div className="relative h-[640px]">
-                  <div className="absolute left-1/2 top-[320px] -translate-x-1/2">
-                    <div
-                      className="absolute left-1/2 h-20 w-px -translate-x-1/2"
-                      style={{
-                        top: above ? "4px" : "auto",
-                        bottom: above ? "auto" : "4px",
-                        background: active ? color.line : "hsl(var(--border))",
-                        boxShadow: active ? `0 0 10px ${color.glow}` : undefined,
-                      }}
-                    />
-                  </div>
+              <div key={event.event_id} data-month={monthKey} className="relative w-[430px] shrink-0 px-5">
+                <div className="relative h-[700px]">
+                  <div
+                    aria-hidden="true"
+                    className="pointer-events-none absolute left-1/2 top-[320px] z-[2] h-20 w-px -translate-x-1/2"
+                    style={{
+                      top: above ? "260px" : "320px",
+                      background: active ? color.line : "hsl(var(--border))",
+                      boxShadow: active ? `0 0 10px ${color.glow}` : undefined,
+                    }}
+                  />
 
-                  <div className={`absolute left-1/2 w-full -translate-x-1/2 ${above ? "bottom-[340px]" : "top-[340px]"}`}>
+                  <div className={`absolute left-1/2 w-[390px] -translate-x-1/2 ${above ? "bottom-[380px]" : "top-[360px]"}`}>
                     <TimelineCard
                       event={event}
                       above={above}
@@ -268,26 +307,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
         </div>
       </div>
 
-      <div className="mt-4 flex items-center justify-center gap-2 overflow-x-auto px-5 pb-1">
-        {monthMarkers.map((month) => {
-          const color = getTimelineColorForMonth(month.key, monthMarkers);
-          const active = month.key === activeMonth;
-          return (
-            <button
-              key={month.key}
-              type="button"
-              onClick={() => jumpToMonth(month.key)}
-              className={`shrink-0 rounded-full border px-3 py-1.5 text-[11px] font-medium transition ${active ? "text-foreground shadow-sm" : "text-muted-foreground"}`}
-              style={{
-                borderColor: active ? color.line : color.glow,
-                background: active ? color.glow : "transparent",
-              }}
-            >
-              {month.label}
-            </button>
-          );
-        })}
-      </div>
+      <div className="mt-4 px-5 sm:px-8 lg:px-12">{monthFilter}</div>
     </section>
   );
 }

--- a/src/components/space/timeline/AdaptiveTimelineRail.jsx
+++ b/src/components/space/timeline/AdaptiveTimelineRail.jsx
@@ -18,6 +18,10 @@ function getPreferredOrientation(value, width) {
     : TIMELINE_ORIENTATION.HORIZONTAL;
 }
 
+function monthLabelPosition(above) {
+  return above ? "bottom-[382px]" : "top-[362px]";
+}
+
 export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth, onMonthChange, onSelectEvent }) {
   const [preference, setPreference] = useState(TIMELINE_ORIENTATION.AUTO);
   const [width, setWidth] = useState(1440);
@@ -109,41 +113,20 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
 
   const renderToggle = () => (
     <div className="flex items-center gap-1 rounded-full border bg-background/80 p-1 backdrop-blur">
-      <Button
-        type="button"
-        variant={preference === TIMELINE_ORIENTATION.AUTO ? "secondary" : "ghost"}
-        size="icon"
-        className="h-8 w-8 rounded-full"
-        onClick={() => setPreference(TIMELINE_ORIENTATION.AUTO)}
-        title="Automatic timeline layout"
-      >
+      <Button type="button" variant={preference === TIMELINE_ORIENTATION.AUTO ? "secondary" : "ghost"} size="icon" className="h-8 w-8 rounded-full" onClick={() => setPreference(TIMELINE_ORIENTATION.AUTO)} title="Automatic timeline layout">
         <Monitor className="h-3.5 w-3.5" />
       </Button>
-      <Button
-        type="button"
-        variant={preference === TIMELINE_ORIENTATION.HORIZONTAL ? "secondary" : "ghost"}
-        size="icon"
-        className="h-8 w-8 rounded-full"
-        onClick={() => setPreference(TIMELINE_ORIENTATION.HORIZONTAL)}
-        title="Horizontal timeline"
-      >
+      <Button type="button" variant={preference === TIMELINE_ORIENTATION.HORIZONTAL ? "secondary" : "ghost"} size="icon" className="h-8 w-8 rounded-full" onClick={() => setPreference(TIMELINE_ORIENTATION.HORIZONTAL)} title="Horizontal timeline">
         <Columns3 className="h-3.5 w-3.5" />
       </Button>
-      <Button
-        type="button"
-        variant={preference === TIMELINE_ORIENTATION.VERTICAL ? "secondary" : "ghost"}
-        size="icon"
-        className="h-8 w-8 rounded-full"
-        onClick={() => setPreference(TIMELINE_ORIENTATION.VERTICAL)}
-        title="Vertical timeline"
-      >
+      <Button type="button" variant={preference === TIMELINE_ORIENTATION.VERTICAL ? "secondary" : "ghost"} size="icon" className="h-8 w-8 rounded-full" onClick={() => setPreference(TIMELINE_ORIENTATION.VERTICAL)} title="Vertical timeline">
         <Rows3 className="h-3.5 w-3.5" />
       </Button>
     </div>
   );
 
-  const monthFilter = (
-    <div className="flex gap-2 overflow-x-auto pb-1">
+  const monthFilter = (vertical = false) => (
+    <div className={vertical ? "flex flex-col gap-2" : "flex gap-2 overflow-x-auto pb-1"}>
       {monthMarkers.map((month) => {
         const color = getTimelineColorForMonth(month.key, monthMarkers);
         const active = month.key === activeMonth;
@@ -153,10 +136,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
             type="button"
             onClick={() => jumpToMonth(month.key)}
             className={`shrink-0 rounded-full border px-3 py-1.5 text-[11px] font-medium transition ${active ? "text-foreground shadow-sm" : "text-muted-foreground"}`}
-            style={{
-              borderColor: active ? color.line : color.glow,
-              background: active ? color.glow : "transparent",
-            }}
+            style={{ borderColor: active ? color.line : color.glow, background: active ? color.glow : "transparent" }}
           >
             {month.label}
           </button>
@@ -167,69 +147,51 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
 
   if (orientation === TIMELINE_ORIENTATION.VERTICAL) {
     return (
-      <section className="mx-auto w-full max-w-6xl pb-20 px-4 sm:px-6 lg:px-8">
+      <section className="mx-auto w-full max-w-7xl pb-20 px-4 sm:px-6 lg:px-8">
         <div className="mb-5 flex items-center justify-between gap-4">
           <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Timeline layout</div>
           {renderToggle()}
         </div>
 
-        <div className="relative md:pl-28">
-          <aside className="mb-6 md:sticky md:top-24 md:float-left md:ml-[-7rem] md:w-24">
+        <div className="relative md:pl-40">
+          <aside className="mb-6 md:fixed md:left-6 md:top-32 md:z-20 md:w-28">
             <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">Months</div>
-            <div className="mt-3 max-h-[70vh] overflow-y-auto pr-1">
-              <div className="flex gap-2 overflow-x-auto md:flex-col md:overflow-x-visible">{monthFilter}</div>
+            <div className="mt-3 max-h-[72vh] overflow-y-auto pr-1">
+              {monthFilter(true)}
             </div>
           </aside>
 
           <div className="relative mx-auto max-w-5xl">
             <div className="pointer-events-none absolute left-1/2 top-0 hidden h-full w-px -translate-x-1/2 bg-border md:block" />
-            <div
-              className="pointer-events-none absolute left-1/2 top-0 hidden w-px -translate-x-1/2 md:block"
-              style={{
-                height: `${progress}%`,
-                background: activeColor.line,
-                boxShadow: `0 0 14px ${activeColor.glow}`,
-              }}
-            />
+            <div className="pointer-events-none absolute left-1/2 top-0 hidden w-px -translate-x-1/2 md:block" style={{ height: `${progress}%`, background: activeColor.line, boxShadow: `0 0 14px ${activeColor.glow}` }} />
 
-            <div className="space-y-14 md:space-y-20">
+            <div className="space-y-24 md:space-y-28">
               {events.map((event, index) => {
                 const date = new Date(event.occurred_at);
                 const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
                 const monthIndex = monthMarkers.findIndex((month) => month.key === monthKey);
                 const color = getTimelineColorForMonth(monthKey, monthMarkers);
                 const active = activeMonth === monthKey;
-                const above = index % 2 === 0;
+                const left = index % 2 === 0;
 
                 return (
-                  <div key={event.event_id} className="relative grid items-center md:grid-cols-[1fr_96px_1fr] md:gap-0" data-month={monthKey}>
-                    <div className={`${above ? "md:col-start-1 md:pr-10" : "md:col-start-3 md:pl-10"}`}>
-                      <TimelineCard
-                        event={event}
-                        above={above}
-                        active={active}
-                        color={color}
-                        onSelect={onSelectEvent}
-                        orientation={TIMELINE_ORIENTATION.VERTICAL}
-                        monthIndex={Math.max(monthIndex, 0)}
-                      />
+                  <div key={event.event_id} data-month={monthKey} className="relative min-h-[300px] md:grid md:grid-cols-[1fr_180px_1fr] md:items-center">
+                    <div className={left ? "md:col-start-1 md:pr-12" : "md:col-start-3 md:pl-12"}>
+                      <TimelineCard event={event} active={active} color={color} onSelect={onSelectEvent} orientation={TIMELINE_ORIENTATION.VERTICAL} monthIndex={Math.max(monthIndex, 0)} />
                     </div>
 
-                    <div className="relative z-20 hidden min-h-[250px] md:flex md:items-center md:justify-center">
-                      <div
-                        className="absolute left-1/2 top-1/2 h-px w-12 -translate-y-1/2"
-                        style={{ background: active ? color.line : "hsl(var(--border))" }}
-                      />
-                      <motion.div
-                        className="relative h-3.5 w-3.5 rounded-full border-2 bg-background"
-                        animate={{ scale: active ? 1.25 : 1 }}
-                        transition={{ duration: 0.2 }}
-                        style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }}
-                      />
+                    <div className="relative hidden min-h-[300px] md:block md:col-start-2">
+                      <div className="absolute left-1/2 top-1/2 z-10 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 bg-background" style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }} />
+                      <div className="absolute left-1/2 top-1/2 h-px w-16 -translate-y-1/2" style={{ background: active ? color.line : "hsl(var(--border))", transformOrigin: left ? "right center" : "left center" }} />
+                      <div className={`absolute top-1/2 -translate-y-1/2 ${left ? "right-0 mr-12" : "left-0 ml-12"}`}>
+                        <div className="whitespace-nowrap text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}>
+                          {monthMarkers[monthIndex]?.label}
+                        </div>
+                      </div>
                     </div>
 
-                    <div className="mt-3 md:hidden">
-                      <div className="ml-4 h-8 w-px bg-border" />
+                    <div className="md:hidden">
+                      <div className="mt-4 ml-4 h-8 w-px" style={{ background: color.line }} />
                     </div>
                   </div>
                 );
@@ -245,28 +207,13 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
     <section className="relative pb-16">
       <div className="mb-5 flex items-center justify-between gap-4 px-5 sm:px-8 lg:px-12">
         <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Timeline layout</div>
-        <div className="flex items-center gap-2">
-          {renderToggle()}
-          <Button variant="outline" size="icon" className="rounded-full" onClick={() => jumpHorizontal(-1)}>
-            <ChevronLeft className="h-4 w-4" />
-          </Button>
-          <Button variant="outline" size="icon" className="rounded-full" onClick={() => jumpHorizontal(1)}>
-            <ChevronRight className="h-4 w-4" />
-          </Button>
-        </div>
+        <div className="flex items-center gap-2">{renderToggle()}<Button variant="outline" size="icon" className="rounded-full" onClick={() => jumpHorizontal(-1)}><ChevronLeft className="h-4 w-4" /></Button><Button variant="outline" size="icon" className="rounded-full" onClick={() => jumpHorizontal(1)}><ChevronRight className="h-4 w-4" /></Button></div>
       </div>
 
       <div ref={railRef} className="scrollbar-hide overflow-x-auto overflow-y-hidden px-[7vw] py-8 sm:px-[8vw]">
         <div className="relative mx-auto flex min-w-max items-center">
-          <div className="pointer-events-none absolute left-0 right-0 top-[320px] z-0 h-[3px] rounded-full bg-muted/90" />
-          <Progress value={progress} className="pointer-events-none absolute left-0 right-0 top-[320px] z-0">
-            <ProgressTrack className="h-[3px] bg-transparent">
-              <ProgressIndicator
-                className="h-full transition-none"
-                style={{ background: activeColor.line, boxShadow: `0 0 12px ${activeColor.glow}` }}
-              />
-            </ProgressTrack>
-          </Progress>
+          <div className="pointer-events-none absolute left-0 right-0 top-[340px] z-0 h-[3px] rounded-full bg-muted/90" />
+          <Progress value={progress} className="pointer-events-none absolute left-0 right-0 top-[340px] z-0"><ProgressTrack className="h-[3px] bg-transparent"><ProgressIndicator className="h-full transition-none" style={{ background: activeColor.line, boxShadow: `0 0 12px ${activeColor.glow}` }} /></ProgressTrack></Progress>
 
           {events.map((event, index) => {
             const date = new Date(event.occurred_at);
@@ -275,30 +222,20 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
             const color = getTimelineColorForMonth(monthKey, monthMarkers);
             const active = activeMonth === monthKey;
             const above = index % 2 === 0;
+            const monthLabel = monthMarkers[monthIndex]?.label;
 
             return (
-              <div key={event.event_id} data-month={monthKey} className="relative w-[430px] shrink-0 px-5">
-                <div className="relative h-[700px]">
-                  <div
-                    aria-hidden="true"
-                    className="pointer-events-none absolute left-1/2 top-[320px] z-[2] h-20 w-px -translate-x-1/2"
-                    style={{
-                      top: above ? "260px" : "320px",
-                      background: active ? color.line : "hsl(var(--border))",
-                      boxShadow: active ? `0 0 10px ${color.glow}` : undefined,
-                    }}
-                  />
+              <div key={event.event_id} data-month={monthKey} className="relative w-[460px] shrink-0 px-5">
+                <div className="relative h-[720px]">
+                  <div className={`absolute left-1/2 z-10 w-[390px] -translate-x-1/2 ${above ? "bottom-[390px]" : "top-[390px]"}`}>
+                    <TimelineCard event={event} active={active} color={color} onSelect={onSelectEvent} orientation={TIMELINE_ORIENTATION.HORIZONTAL} monthIndex={Math.max(monthIndex, 0)} />
+                  </div>
 
-                  <div className={`absolute left-1/2 w-[390px] -translate-x-1/2 ${above ? "bottom-[380px]" : "top-[360px]"}`}>
-                    <TimelineCard
-                      event={event}
-                      above={above}
-                      active={active}
-                      color={color}
-                      onSelect={onSelectEvent}
-                      orientation={TIMELINE_ORIENTATION.HORIZONTAL}
-                      monthIndex={Math.max(monthIndex, 0)}
-                    />
+                  <div className="absolute left-1/2 top-[340px] z-20 h-px w-16 -translate-x-1/2" style={{ background: active ? color.line : "hsl(var(--border))" }} />
+                  <div className="absolute left-1/2 top-[340px] z-20 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 bg-background" style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }} />
+                  <div className={`absolute left-1/2 z-20 -translate-x-1/2 ${above ? "bottom-[360px]" : "top-[360px]"}`}>
+                    <div className="h-10 w-px" style={{ background: active ? color.line : "hsl(var(--border))" }} />
+                    <div className={`mt-2 whitespace-nowrap text-[11px] font-semibold uppercase tracking-[0.16em] ${active ? "opacity-100" : "opacity-70"}`} style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}>{monthLabel}</div>
                   </div>
                 </div>
               </div>
@@ -307,7 +244,7 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
         </div>
       </div>
 
-      <div className="mt-4 px-5 sm:px-8 lg:px-12">{monthFilter}</div>
+      <div className="mt-4 px-5 sm:px-8 lg:px-12">{monthFilter(false)}</div>
     </section>
   );
 }

--- a/src/components/space/timeline/AdaptiveTimelineRail.jsx
+++ b/src/components/space/timeline/AdaptiveTimelineRail.jsx
@@ -18,10 +18,6 @@ function getPreferredOrientation(value, width) {
     : TIMELINE_ORIENTATION.HORIZONTAL;
 }
 
-function monthLabelPosition(above) {
-  return above ? "bottom-[382px]" : "top-[362px]";
-}
-
 export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth, onMonthChange, onSelectEvent }) {
   const [preference, setPreference] = useState(TIMELINE_ORIENTATION.AUTO);
   const [width, setWidth] = useState(1440);
@@ -104,10 +100,8 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
       return;
     }
 
-    document.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({
-      behavior: "smooth",
-      block: "center",
-    });
+    const target = document.querySelector(`[data-month="${monthKey}"]`);
+    target?.scrollIntoView({ behavior: "smooth", block: "center" });
     onMonthChange(monthKey);
   };
 
@@ -153,19 +147,20 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
           {renderToggle()}
         </div>
 
-        <div className="relative md:pl-40">
-          <aside className="mb-6 md:fixed md:left-6 md:top-32 md:z-20 md:w-28">
+        <div className="relative md:pl-44">
+          <aside className="md:sticky md:top-24 md:z-20 md:float-left md:ml-[-11rem] md:w-36">
             <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">Months</div>
-            <div className="mt-3 max-h-[72vh] overflow-y-auto pr-1">
-              {monthFilter(true)}
-            </div>
+            <div className="mt-3 max-h-[70vh] overflow-y-auto pr-1">{monthFilter(true)}</div>
           </aside>
 
           <div className="relative mx-auto max-w-5xl">
             <div className="pointer-events-none absolute left-1/2 top-0 hidden h-full w-px -translate-x-1/2 bg-border md:block" />
-            <div className="pointer-events-none absolute left-1/2 top-0 hidden w-px -translate-x-1/2 md:block" style={{ height: `${progress}%`, background: activeColor.line, boxShadow: `0 0 14px ${activeColor.glow}` }} />
+            <div
+              className="pointer-events-none absolute left-1/2 top-0 hidden w-px -translate-x-1/2 md:block"
+              style={{ height: `${progress}%`, background: activeColor.line, boxShadow: `0 0 14px ${activeColor.glow}` }}
+            />
 
-            <div className="space-y-24 md:space-y-28">
+            <div className="space-y-28 md:space-y-32">
               {events.map((event, index) => {
                 const date = new Date(event.occurred_at);
                 const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
@@ -173,25 +168,42 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
                 const color = getTimelineColorForMonth(monthKey, monthMarkers);
                 const active = activeMonth === monthKey;
                 const left = index % 2 === 0;
+                const monthLabel = monthMarkers[monthIndex]?.label;
 
                 return (
-                  <div key={event.event_id} data-month={monthKey} className="relative min-h-[300px] md:grid md:grid-cols-[1fr_180px_1fr] md:items-center">
-                    <div className={left ? "md:col-start-1 md:pr-12" : "md:col-start-3 md:pl-12"}>
-                      <TimelineCard event={event} active={active} color={color} onSelect={onSelectEvent} orientation={TIMELINE_ORIENTATION.VERTICAL} monthIndex={Math.max(monthIndex, 0)} />
+                  <div key={event.event_id} data-month={monthKey} className="relative min-h-[300px] md:grid md:grid-cols-[minmax(0,1fr)_220px_minmax(0,1fr)] md:items-center">
+                    <div className={left ? "md:col-start-1 md:pr-14" : "md:col-start-3 md:pl-14"}>
+                      <TimelineCard
+                        event={event}
+                        active={active}
+                        color={color}
+                        onSelect={onSelectEvent}
+                        orientation={TIMELINE_ORIENTATION.VERTICAL}
+                        monthIndex={Math.max(monthIndex, 0)}
+                      />
                     </div>
 
-                    <div className="relative hidden min-h-[300px] md:block md:col-start-2">
-                      <div className="absolute left-1/2 top-1/2 z-10 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 bg-background" style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }} />
-                      <div className="absolute left-1/2 top-1/2 h-px w-16 -translate-y-1/2" style={{ background: active ? color.line : "hsl(var(--border))", transformOrigin: left ? "right center" : "left center" }} />
-                      <div className={`absolute top-1/2 -translate-y-1/2 ${left ? "right-0 mr-12" : "left-0 ml-12"}`}>
-                        <div className="whitespace-nowrap text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}>
-                          {monthMarkers[monthIndex]?.label}
+                    <div className="relative hidden min-h-[300px] md:col-start-2 md:block">
+                      <div
+                        className={`absolute top-1/2 -translate-y-1/2 ${left ? "right-0 mr-10" : "left-0 ml-10"}`}
+                        style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}
+                      >
+                        <div className="whitespace-nowrap text-[11px] font-semibold uppercase tracking-[0.16em]">
+                          {monthLabel}
                         </div>
                       </div>
-                    </div>
 
-                    <div className="md:hidden">
-                      <div className="mt-4 ml-4 h-8 w-px" style={{ background: color.line }} />
+                      <div
+                        className={`absolute top-1/2 h-px -translate-y-1/2 ${left ? "left-0 right-1/2 ml-2 mr-2" : "left-1/2 right-0 ml-2 mr-2"}`}
+                        style={{ background: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 8px ${color.glow}` : undefined }}
+                      />
+
+                      <motion.div
+                        className="absolute left-1/2 top-1/2 z-20 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 bg-background"
+                        animate={{ scale: active ? 1.2 : 1 }}
+                        transition={{ duration: 0.2 }}
+                        style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }}
+                      />
                     </div>
                   </div>
                 );
@@ -213,7 +225,9 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
       <div ref={railRef} className="scrollbar-hide overflow-x-auto overflow-y-hidden px-[7vw] py-8 sm:px-[8vw]">
         <div className="relative mx-auto flex min-w-max items-center">
           <div className="pointer-events-none absolute left-0 right-0 top-[340px] z-0 h-[3px] rounded-full bg-muted/90" />
-          <Progress value={progress} className="pointer-events-none absolute left-0 right-0 top-[340px] z-0"><ProgressTrack className="h-[3px] bg-transparent"><ProgressIndicator className="h-full transition-none" style={{ background: activeColor.line, boxShadow: `0 0 12px ${activeColor.glow}` }} /></ProgressTrack></Progress>
+          <Progress value={progress} className="pointer-events-none absolute left-0 right-0 top-[340px] z-0">
+            <ProgressTrack className="h-[3px] bg-transparent"><ProgressIndicator className="h-full transition-none" style={{ background: activeColor.line, boxShadow: `0 0 12px ${activeColor.glow}` }} /></ProgressTrack>
+          </Progress>
 
           {events.map((event, index) => {
             const date = new Date(event.occurred_at);
@@ -228,15 +242,22 @@ export default function AdaptiveTimelineRail({ events, monthMarkers, activeMonth
               <div key={event.event_id} data-month={monthKey} className="relative w-[460px] shrink-0 px-5">
                 <div className="relative h-[720px]">
                   <div className={`absolute left-1/2 z-10 w-[390px] -translate-x-1/2 ${above ? "bottom-[390px]" : "top-[390px]"}`}>
-                    <TimelineCard event={event} active={active} color={color} onSelect={onSelectEvent} orientation={TIMELINE_ORIENTATION.HORIZONTAL} monthIndex={Math.max(monthIndex, 0)} />
+                    <div className={`relative ${above ? "pb-12" : "pt-12"}`}>
+                      <div className={`absolute left-1/2 z-20 -translate-x-1/2 whitespace-nowrap text-[11px] font-semibold uppercase tracking-[0.16em] ${above ? "bottom-2" : "top-2"}`} style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}>
+                        {monthLabel}
+                      </div>
+                      <TimelineCard event={event} active={active} color={color} onSelect={onSelectEvent} orientation={TIMELINE_ORIENTATION.HORIZONTAL} monthIndex={Math.max(monthIndex, 0)} />
+                    </div>
                   </div>
 
-                  <div className="absolute left-1/2 top-[340px] z-20 h-px w-16 -translate-x-1/2" style={{ background: active ? color.line : "hsl(var(--border))" }} />
-                  <div className="absolute left-1/2 top-[340px] z-20 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 bg-background" style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }} />
-                  <div className={`absolute left-1/2 z-20 -translate-x-1/2 ${above ? "bottom-[360px]" : "top-[360px]"}`}>
-                    <div className="h-10 w-px" style={{ background: active ? color.line : "hsl(var(--border))" }} />
-                    <div className={`mt-2 whitespace-nowrap text-[11px] font-semibold uppercase tracking-[0.16em] ${active ? "opacity-100" : "opacity-70"}`} style={{ color: active ? color.line : "hsl(var(--muted-foreground))" }}>{monthLabel}</div>
-                  </div>
+                  <div
+                    className="absolute left-1/2 top-[340px] z-20 h-px w-16 -translate-x-1/2"
+                    style={{ background: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 8px ${color.glow}` : undefined }}
+                  />
+                  <div
+                    className="absolute left-1/2 top-[340px] z-20 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 bg-background"
+                    style={{ borderColor: active ? color.line : "hsl(var(--border))", boxShadow: active ? `0 0 16px ${color.glow}` : undefined }}
+                  />
                 </div>
               </div>
             );

--- a/src/components/space/timeline/TimelineCard.jsx
+++ b/src/components/space/timeline/TimelineCard.jsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { format } from "date-fns";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import AutoImageCarousel from "@/components/attachment/AutoImageCarousel";
+import { TIMELINE_FALLBACK_IMAGES, getTimelineColor, TIMELINE_NATURAL_TEXT } from "@/config/timeline";
+
+function safeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function pickVariant(event, items) {
+  const key = String(event.event_id || event.post_id || event.title || "timeline");
+  let hash = 0;
+  for (let index = 0; index < key.length; index += 1) hash = (hash * 31 + key.charCodeAt(index)) >>> 0;
+  return items[hash % items.length];
+}
+
+function getFallbackImage(event) {
+  return TIMELINE_FALLBACK_IMAGES[event?.event_type] || TIMELINE_FALLBACK_IMAGES.post;
+}
+
+export default function TimelineCard({ event, active, onSelect, monthIndex = 0, orientation = "horizontal", color }) {
+  const date = new Date(event.occurred_at);
+  const attachments = safeArray(event.attachments).filter((item) => item?.mime_type?.startsWith("image/"));
+  const governance = safeArray(event.governance_entities);
+  const resolvedColor = color || getTimelineColor(date.getFullYear(), monthIndex);
+  const fallback = getFallbackImage(event);
+  const naturalItems = TIMELINE_NATURAL_TEXT[event.event_type] || TIMELINE_NATURAL_TEXT.post || ["A moment worth keeping"];
+  const natural = pickVariant(event, naturalItems);
+  const vertical = orientation === "vertical";
+
+  return (
+    <motion.button
+      type="button"
+      onClick={() => onSelect(event)}
+      className={`group relative block h-[230px] w-full max-w-[420px] overflow-hidden rounded-[30px] border bg-background text-left shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary ${vertical ? "sm:max-w-[440px]" : "w-[350px]"}`}
+      initial={{ opacity: 0, y: 16 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.2 }}
+      transition={{ duration: 0.38 }}
+      style={{
+        borderColor: active ? resolvedColor.line : "hsl(var(--border))",
+        boxShadow: active ? `0 0 0 1px ${resolvedColor.line}, 0 0 28px ${resolvedColor.glow}` : undefined,
+      }}
+    >
+      {attachments.length ? (
+        <AutoImageCarousel attachments={attachments} />
+      ) : (
+        <img src={fallback} alt="" className="absolute inset-0 h-full w-full object-cover" />
+      )}
+
+      <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/15 to-transparent" />
+
+      <div className="absolute left-4 top-4 rounded-full border border-white/15 bg-black/25 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-white backdrop-blur">
+        {format(date, "d MMM")}
+      </div>
+
+      {governance.length ? (
+        <div className="absolute right-4 top-4 flex -space-x-1.5">
+          {governance.slice(0, 3).map((item) => (
+            item.image_url ? (
+              <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" />
+            ) : (
+              <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">
+                {(item.short_name || item.label || "G").charAt(0)}
+              </div>
+            )
+          ))}
+        </div>
+      ) : null}
+
+      {event.event_type === "member_joined" ? (
+        <div className="absolute bottom-20 left-4 flex items-center gap-2 rounded-full bg-black/35 px-2 py-1.5 text-white backdrop-blur">
+          <Avatar className="h-7 w-7 border border-white/20">
+            <AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} />
+            <AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback>
+          </Avatar>
+          <span className="max-w-[170px] truncate text-xs font-medium">{event.actor_name || "New member"}</span>
+        </div>
+      ) : null}
+
+      <div className="absolute inset-x-4 bottom-4 text-white">
+        <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/70">{natural}</div>
+        <div className="mt-1 line-clamp-2 text-lg font-semibold leading-tight">{event.title}</div>
+      </div>
+    </motion.button>
+  );
+}

--- a/src/components/ui/progress.jsx
+++ b/src/components/ui/progress.jsx
@@ -1,82 +1,31 @@
-import { Progress as ProgressPrimitive } from "@base-ui/react/progress"
+"use client"
+
+import * as React from "react"
+import { Progress as ProgressPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
 function Progress({
   className,
-  children,
   value,
   ...props
-}) {
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
   return (
     <ProgressPrimitive.Root
-      value={value}
       data-slot="progress"
-      className={cn("flex flex-wrap gap-3", className)}
-      {...props}>
-      {children}
-      <ProgressTrack>
-        <ProgressIndicator />
-      </ProgressTrack>
-    </ProgressPrimitive.Root>
-  );
-}
-
-function ProgressTrack({
-  className,
-  ...props
-}) {
-  return (
-    <ProgressPrimitive.Track
       className={cn(
         "relative flex h-1 w-full items-center overflow-x-hidden rounded-full bg-muted",
         className
       )}
-      data-slot="progress-track"
-      {...props} />
-  );
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="size-full flex-1 bg-primary transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  )
 }
 
-function ProgressIndicator({
-  className,
-  ...props
-}) {
-  return (
-    <ProgressPrimitive.Indicator
-      data-slot="progress-indicator"
-      className={cn("h-full bg-primary transition-all", className)}
-      {...props} />
-  );
-}
-
-function ProgressLabel({
-  className,
-  ...props
-}) {
-  return (
-    <ProgressPrimitive.Label
-      className={cn("text-sm font-medium", className)}
-      data-slot="progress-label"
-      {...props} />
-  );
-}
-
-function ProgressValue({
-  className,
-  ...props
-}) {
-  return (
-    <ProgressPrimitive.Value
-      className={cn("ml-auto text-sm text-muted-foreground tabular-nums", className)}
-      data-slot="progress-value"
-      {...props} />
-  );
-}
-
-export {
-  Progress,
-  ProgressTrack,
-  ProgressIndicator,
-  ProgressLabel,
-  ProgressValue,
-}
+export { Progress }

--- a/src/components/ui/progress.jsx
+++ b/src/components/ui/progress.jsx
@@ -9,7 +9,7 @@ function Progress({
   className,
   value,
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}) {
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
@@ -17,6 +17,7 @@ function Progress({
         "relative flex h-1 w-full items-center overflow-x-hidden rounded-full bg-muted",
         className
       )}
+      value={value}
       {...props}
     >
       <ProgressPrimitive.Indicator

--- a/src/config/timeline/colors.js
+++ b/src/config/timeline/colors.js
@@ -1,0 +1,18 @@
+export const TIMELINE_COLORS = [
+  { name: "blue", line: "#2563eb", glow: "rgba(37,99,235,0.18)", dark: "#1d4ed8" },
+  { name: "green", line: "#059669", glow: "rgba(5,150,105,0.18)", dark: "#047857" },
+  { name: "amber", line: "#d97706", glow: "rgba(217,119,6,0.18)", dark: "#b45309" },
+  { name: "violet", line: "#7c3aed", glow: "rgba(124,58,237,0.18)", dark: "#6d28d9" },
+  { name: "pink", line: "#db2777", glow: "rgba(219,39,119,0.18)", dark: "#be185d" },
+];
+
+export function getTimelineColor(year, monthIndex = 0) {
+  const index = Math.abs(Number(year || 0) * 12 + Number(monthIndex || 0)) % TIMELINE_COLORS.length;
+  return TIMELINE_COLORS[index];
+}
+
+export function getTimelineColorForMonth(monthKey, monthMarkers = []) {
+  const index = Math.max(0, monthMarkers.findIndex((month) => month.key === monthKey));
+  const year = Number(String(monthKey || "0").slice(0, 4));
+  return getTimelineColor(year, index);
+}

--- a/src/config/timeline/fallbackImages.js
+++ b/src/config/timeline/fallbackImages.js
@@ -1,0 +1,10 @@
+export const TIMELINE_FALLBACK_IMAGES = {
+  report: "/timeline/report-default.jpg",
+  meeting: "/timeline/meeting-default.jpg",
+  event: "/timeline/event-default.jpg",
+  action: "/timeline/action-default.jpg",
+  member_joined: "/timeline/member-default.jpg",
+  announcement: "/timeline/announcement-default.jpg",
+  post: "/timeline/project-default.jpg",
+  space_created: "/timeline/project-default.jpg",
+};

--- a/src/config/timeline/governanceLanguage.js
+++ b/src/config/timeline/governanceLanguage.js
@@ -1,0 +1,30 @@
+export const GOVERNANCE_LANGUAGE = {
+  authority: ["under", "with", "in conversation with"],
+  department: ["within", "through", "with"],
+  official: ["with", "in conversation with", "alongside"],
+  organization: ["alongside", "with", "working with"],
+  person: ["with", "alongside", "in conversation with"],
+};
+
+export const GOVERNANCE_RELATIONSHIP_LANGUAGE = {
+  responsibility: [
+    "worked under",
+    "sat within the responsibility of",
+    "fell under",
+  ],
+  collaboration: [
+    "worked alongside",
+    "worked with",
+    "collaborated with",
+  ],
+  engagement: [
+    "was in conversation with",
+    "engaged with",
+    "met with",
+  ],
+  general: [
+    "worked with",
+    "worked alongside",
+    "was in conversation with",
+  ],
+};

--- a/src/config/timeline/index.js
+++ b/src/config/timeline/index.js
@@ -1,0 +1,4 @@
+export { TIMELINE_NATURAL_TEXT } from "./naturalText";
+export { GOVERNANCE_LANGUAGE, GOVERNANCE_RELATIONSHIP_LANGUAGE } from "./governanceLanguage";
+export { TIMELINE_COLORS, getTimelineColor, getTimelineColorForMonth } from "./colors";
+export { TIMELINE_FALLBACK_IMAGES } from "./fallbackImages";

--- a/src/config/timeline/naturalText.js
+++ b/src/config/timeline/naturalText.js
@@ -1,0 +1,58 @@
+export const TIMELINE_NATURAL_TEXT = {
+  space_created: [
+    "This is where the story began",
+    "This is where the work started",
+    "The first page of the story",
+    "The beginning of something local",
+    "This is where it all came together",
+  ],
+  member_joined: [
+    "Someone new joined the team",
+    "Another person came on board",
+    "The team grew a little stronger",
+    "A new contributor joined in",
+    "Another pair of hands joined the effort",
+  ],
+  report: [
+    "A piece of work took shape",
+    "The team moved an idea forward",
+    "Something useful came together",
+    "The team put its findings on record",
+    "The work turned into something concrete",
+  ],
+  meeting: [
+    "The team sat down to work through it",
+    "People came together to figure it out",
+    "A conversation moved the work forward",
+    "The right people got around the table",
+    "The team made time to work through the details",
+  ],
+  event: [
+    "The team showed up",
+    "The team stepped into the wider conversation",
+    "The work met the real world",
+    "The team took part in the moment",
+    "The team was there for it",
+  ],
+  action: [
+    "Something was done",
+    "The team moved from words to action",
+    "A small step became a real action",
+    "The team followed through",
+    "The work moved into the real world",
+  ],
+  announcement: [
+    "Something important was shared",
+    "The team had an update to share",
+    "A new chapter was announced",
+    "The team shared where things stood",
+    "A useful update made its way out",
+  ],
+  post: [
+    "A moment worth keeping",
+    "Something the team wanted on record",
+    "Another piece of the story",
+    "A moment from along the way",
+    "One more chapter in the journey",
+  ],
+};

--- a/src/config/timeline/orientation.js
+++ b/src/config/timeline/orientation.js
@@ -1,0 +1,9 @@
+export const TIMELINE_ORIENTATION = {
+  AUTO: "auto",
+  HORIZONTAL: "horizontal",
+  VERTICAL: "vertical",
+};
+
+export const TIMELINE_BREAKPOINTS = {
+  verticalBelowPx: 1024,
+};

--- a/src/pages/space/[space]/timeline.js
+++ b/src/pages/space/[space]/timeline.js
@@ -1,11 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/router";
 import { motion } from "framer-motion";
-import { ArrowLeft, ArrowRight, History } from "lucide-react";
-import { format } from "date-fns";
+import { History } from "lucide-react";
 
 import { useSpaces } from "@/hooks/space/useSpaces";
 import { useSpaceTimeline } from "@/hooks/space/useSpaceTimeline";
@@ -22,81 +21,8 @@ import BackButton from "@/components/ui/back-button";
 import PageHeaderSkeleton from "@/components/skeletons/PageHeaderSkeleton";
 import AutoImageCarousel from "@/components/attachment/AutoImageCarousel";
 import PostLinks from "@/components/feed/post/PostLinks";
-
-const NATURAL_TEXT = {
-  space_created: [
-    "This is where the story began",
-    "This is where the work started",
-    "The first page of the story",
-    "The beginning of something local",
-    "This is where it all came together",
-  ],
-  member_joined: [
-    "Someone new joined the team",
-    "Another person came on board",
-    "The team grew a little stronger",
-    "A new contributor joined in",
-    "Another pair of hands joined the effort",
-  ],
-  report: [
-    "A piece of work took shape",
-    "The team moved an idea forward",
-    "Something useful came together",
-    "The team put its findings on record",
-    "The work turned into something concrete",
-  ],
-  meeting: [
-    "The team sat down to work through it",
-    "People came together to figure it out",
-    "A conversation moved the work forward",
-    "The right people got around the table",
-    "The team made time to work through the details",
-  ],
-  event: [
-    "The team showed up",
-    "The team stepped into the wider conversation",
-    "The work met the real world",
-    "The team took part in the moment",
-    "The team was there for it",
-  ],
-  action: [
-    "Something was done",
-    "The team moved from words to action",
-    "A small step became a real action",
-    "The team followed through",
-    "The work moved into the real world",
-  ],
-  announcement: [
-    "Something important was shared",
-    "The team had an update to share",
-    "A new chapter was announced",
-    "The team shared where things stood",
-    "A useful update made its way out",
-  ],
-  post: [
-    "A moment worth keeping",
-    "Something the team wanted on record",
-    "Another piece of the story",
-    "A moment from along the way",
-    "One more chapter in the journey",
-  ],
-};
-
-const GOVERNANCE_TEXT = {
-  authority: ["under", "with", "in conversation with"],
-  department: ["within", "through", "with"],
-  official: ["with", "in conversation with", "alongside"],
-  organization: ["alongside", "with", "working with"],
-  person: ["with", "alongside", "in conversation with"],
-};
-
-const TIMELINE_COLORS = [
-  { line: "#2563eb", soft: "rgba(37,99,235,0.16)", dark: "#1d4ed8" },
-  { line: "#059669", soft: "rgba(5,150,105,0.16)", dark: "#047857" },
-  { line: "#d97706", soft: "rgba(217,119,6,0.16)", dark: "#b45309" },
-  { line: "#7c3aed", soft: "rgba(124,58,237,0.16)", dark: "#6d28d9" },
-  { line: "#db2777", soft: "rgba(219,39,119,0.16)", dark: "#be185d" },
-];
+import AdaptiveTimelineRail from "@/components/space/timeline/AdaptiveTimelineRail";
+import { TIMELINE_NATURAL_TEXT, GOVERNANCE_LANGUAGE } from "@/config/timeline";
 
 function safeArray(value) {
   return Array.isArray(value) ? value : [];
@@ -112,58 +38,66 @@ function pickVariant(event, items) {
 }
 
 function naturalLabel(event) {
-  const title = event.title || "this moment";
-  return `${pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}: ${title}.`;
+  const items = TIMELINE_NATURAL_TEXT[event.event_type] || TIMELINE_NATURAL_TEXT.post || [];
+  return `${pickVariant(event, items)}: ${event.title || "this moment"}.`;
 }
 
 function governanceSentence(event, teamName) {
   const governance = safeArray(event.governance_entities);
   if (!governance.length) return null;
+
   const item = governance[0];
   const name = item.short_name || item.label || "an authority";
-  const type = item.entity_type || "authority";
-  const phrase = pickVariant(event, GOVERNANCE_TEXT[type] || GOVERNANCE_TEXT.authority);
   const relationship = String(item.relationship_type || "").toLowerCase();
   const actor = teamName || "The team";
+
   if (relationship.includes("respons") || relationship.includes("owner") || relationship.includes("jurisdiction")) {
     return `${actor} worked under ${name}.`;
   }
+
   if (relationship.includes("collabor") || relationship.includes("partner")) {
     return `${actor} worked alongside ${name}.`;
   }
+
   if (relationship.includes("engag")) {
     return `${actor} was in conversation with ${name}.`;
   }
-  return `${actor} worked ${phrase} ${name}.`;
+
+  const phrases = GOVERNANCE_LANGUAGE[item.entity_type] || GOVERNANCE_LANGUAGE.authority || ["with"];
+  return `${actor} worked ${pickVariant(event, phrases)} ${name}.`;
 }
 
-function MemberIdentity({ event, light = false }) {
+function MemberIdentity({ event }) {
   if (event.event_type !== "member_joined") return null;
+
   return (
-    <div className={`flex items-center gap-2 ${light ? "text-white/85" : "text-foreground"}`}>
-      <Avatar className={`h-9 w-9 border ${light ? "border-white/20" : "border-border"}`}>
+    <div className="flex items-center gap-2 text-foreground">
+      <Avatar className="h-9 w-9 border border-border">
         <AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} />
         <AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback>
       </Avatar>
       <div className="min-w-0">
         <div className="truncate text-sm font-medium">{event.actor_name || "New member"}</div>
-        <div className={`text-[11px] ${light ? "text-white/55" : "text-muted-foreground"}`}>{event.role || "Member"}</div>
+        <div className="text-[11px] text-muted-foreground">{event.role || "Member"}</div>
       </div>
     </div>
   );
 }
 
-function GovernanceRow({ event, light = false }) {
+function GovernanceRow({ event }) {
   const governance = safeArray(event.governance_entities);
   if (!governance.length) return null;
+
   return (
-    <div className={`flex flex-wrap items-center gap-2 ${light ? "text-white/80" : "text-muted-foreground"}`}>
+    <div className="flex flex-wrap items-center gap-2 text-muted-foreground">
       {governance.slice(0, 4).map((item) => (
-        <div key={item.id} className={`flex items-center gap-2 rounded-full border px-2.5 py-1.5 backdrop-blur ${light ? "border-white/15 bg-white/5" : "border-border bg-background/70"}`}>
+        <div key={item.id} className="flex items-center gap-2 rounded-full border border-border bg-background/70 px-2.5 py-1.5 backdrop-blur">
           {item.image_url ? (
             <img src={item.image_url} alt="" className="h-5 w-5 rounded-full object-contain" />
           ) : (
-            <div className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[9px] font-semibold">{(item.short_name || item.label || "G").charAt(0)}</div>
+            <div className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[9px] font-semibold">
+              {(item.short_name || item.label || "G").charAt(0)}
+            </div>
           )}
           <span className="max-w-32 truncate text-[11px] font-medium">{item.short_name || item.label}</span>
         </div>
@@ -176,6 +110,7 @@ function EventDialog({ event, teamName, open, onOpenChange }) {
   const imageAttachments = safeArray(event.attachments).filter((item) => item?.mime_type?.startsWith("image/"));
   const links = safeArray(event.links);
   const governanceCopy = governanceSentence(event, teamName);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[88vh] max-w-4xl overflow-y-auto rounded-[30px] border bg-background p-0">
@@ -185,27 +120,30 @@ function EventDialog({ event, teamName, open, onOpenChange }) {
               <AutoImageCarousel attachments={imageAttachments} />
               <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black/70 to-transparent" />
               <div className="absolute inset-x-6 bottom-5 text-white sm:inset-x-8">
-                <div className="text-xs font-medium uppercase tracking-[0.18em] text-white/70">{format(new Date(event.occurred_at), "d MMMM yyyy")}</div>
                 <DialogTitle className="mt-2 text-3xl font-semibold tracking-tight text-white sm:text-4xl">{event.title}</DialogTitle>
               </div>
             </div>
           ) : null}
+
           <div className="space-y-5 p-6 sm:p-8">
             {!imageAttachments.length ? (
-              <div>
-                <div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{format(new Date(event.occurred_at), "d MMMM yyyy")}</div>
-                <DialogTitle className="mt-2 text-3xl font-semibold tracking-tight sm:text-4xl">{event.title}</DialogTitle>
-              </div>
+              <DialogTitle className="text-3xl font-semibold tracking-tight sm:text-4xl">{event.title}</DialogTitle>
             ) : null}
-            <DialogDescription className="text-base leading-7 text-muted-foreground">{event.description || naturalLabel(event)}</DialogDescription>
-            {event.event_type === "member_joined" ? (
-              <MemberIdentity event={event} />
-            ) : event.actor_name ? (
+
+            <DialogDescription className="text-base leading-7 text-muted-foreground">
+              {event.description || naturalLabel(event)}
+            </DialogDescription>
+
+            {event.event_type === "member_joined" ? <MemberIdentity event={event} /> : event.actor_name ? (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Avatar className="h-8 w-8 border"><AvatarImage src={event.actor_avatar} alt={event.actor_name} /><AvatarFallback>{event.actor_name.charAt(0).toUpperCase()}</AvatarFallback></Avatar>
+                <Avatar className="h-8 w-8 border">
+                  <AvatarImage src={event.actor_avatar} alt={event.actor_name} />
+                  <AvatarFallback>{event.actor_name.charAt(0).toUpperCase()}</AvatarFallback>
+                </Avatar>
                 <span>{event.actor_name}</span>
               </div>
             ) : null}
+
             {governanceCopy ? <p className="text-sm leading-6 text-muted-foreground">{governanceCopy}</p> : null}
             <GovernanceRow event={event} />
             {event.address ? <div className="rounded-2xl border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">{event.address}</div> : null}
@@ -219,156 +157,131 @@ function EventDialog({ event, teamName, open, onOpenChange }) {
 
 export default function SpaceTimelinePage() {
   const router = useRouter();
-  const railRef = useRef(null);
   const { space: slug } = router.query;
+
   const { data: space, isLoading, error } = useSpaces({ slug, enabled: !!slug });
   const { data: timeline = [], isLoading: timelineLoading } = useSpaceTimeline(space?.id);
+
   const [filter, setFilter] = useState("all");
   const [selectedEvent, setSelectedEvent] = useState(null);
   const [activeMonth, setActiveMonth] = useState(null);
 
-  const filteredEvents = useMemo(() => timeline.filter((event) => filter === "all" || event.event_type === filter), [timeline, filter]);
-  const years = useMemo(() => Array.from(new Set(filteredEvents.map((event) => new Date(event.occurred_at).getFullYear()))).sort((a, b) => a - b), [filteredEvents]);
+  const filteredEvents = useMemo(
+    () => timeline.filter((event) => filter === "all" || event.event_type === filter),
+    [timeline, filter],
+  );
+
+  const years = useMemo(
+    () => Array.from(new Set(filteredEvents.map((event) => new Date(event.occurred_at).getFullYear()))).sort((a, b) => a - b),
+    [filteredEvents],
+  );
+
   const monthMarkers = useMemo(() => {
     const seen = new Set();
     return filteredEvents.reduce((markers, event, index) => {
       const date = new Date(event.occurred_at);
-      const key = format(date, "yyyy-MM");
+      const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
       if (seen.has(key)) return markers;
       seen.add(key);
-      markers.push({ key, label: format(date, "MMM yyyy"), year: date.getFullYear(), index });
+      markers.push({
+        key,
+        label: date.toLocaleDateString("en-US", { month: "short", year: "numeric" }),
+        year: date.getFullYear(),
+        index,
+      });
       return markers;
     }, []);
   }, [filteredEvents]);
 
   const teamName = space?.name ? `${space.name} team` : "The team";
-  const activeMonthIndex = activeMonth ? monthMarkers.findIndex((month) => month.key === activeMonth) : -1;
 
-  useEffect(() => {
-    const rail = railRef.current;
-    if (!rail) return undefined;
-    const handleWheel = (event) => {
-      if (Math.abs(event.deltaY) <= Math.abs(event.deltaX) || Math.abs(event.deltaY) < 2) return;
-      const atStart = rail.scrollLeft <= 0 && event.deltaY < 0;
-      const atEnd = rail.scrollLeft + rail.clientWidth >= rail.scrollWidth - 1 && event.deltaY > 0;
-      if (atStart || atEnd) return;
-      event.preventDefault();
-      rail.scrollLeft += event.deltaY;
-    };
-    const handleScroll = () => {
-      const children = rail.querySelectorAll("[data-month]");
-      let closest = null;
-      let distance = Infinity;
-      const center = rail.scrollLeft + rail.clientWidth / 2;
-      children.forEach((child) => {
-        const childCenter = child.offsetLeft + child.offsetWidth / 2;
-        const diff = Math.abs(childCenter - center);
-        if (diff < distance) {
-          distance = diff;
-          closest = child.dataset.month;
-        }
-      });
-      if (closest) setActiveMonth(closest);
-    };
-    rail.addEventListener("wheel", handleWheel, { passive: false });
-    rail.addEventListener("scroll", handleScroll, { passive: true });
-    handleScroll();
-    return () => {
-      rail.removeEventListener("wheel", handleWheel);
-      rail.removeEventListener("scroll", handleScroll);
-    };
-  }, [filteredEvents.length]);
+  if (isLoading || timelineLoading) {
+    return <div className="min-h-dvh bg-background"><PageHeaderSkeleton /></div>;
+  }
 
-  const jump = (direction) => railRef.current?.scrollBy({ left: direction * Math.max(window.innerWidth * 0.72, 460), behavior: "smooth" });
-  const jumpToYear = (year) => railRef.current?.querySelector(`[data-year="${year}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
-  const jumpToMonth = (monthKey) => railRef.current?.querySelector(`[data-month="${monthKey}"]`)?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
-
-  if (isLoading || timelineLoading) return <div className="min-h-dvh bg-background"><PageHeaderSkeleton /></div>;
-  if (error || !space) return <div className="flex min-h-dvh items-center justify-center bg-background px-6 text-center"><div><h1 className="text-2xl font-semibold">Space not found</h1><p className="mt-2 text-muted-foreground">The requested Space does not exist.</p></div></div>;
+  if (error || !space) {
+    return (
+      <div className="flex min-h-dvh items-center justify-center bg-background px-6 text-center">
+        <div>
+          <h1 className="text-2xl font-semibold">Space not found</h1>
+          <p className="mt-2 text-muted-foreground">The requested Space does not exist.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="relative min-h-dvh overflow-hidden bg-background">
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
         <motion.div animate={{ x: [-80, 80, -80], y: [20, -30, 20] }} transition={{ duration: 22, repeat: Infinity, ease: "easeInOut" }} className="absolute left-[-10%] top-[-5%] h-[520px] w-[520px] rounded-full bg-primary/10 blur-[130px]" />
         <motion.div animate={{ x: [70, -70, 70], y: [0, 50, 0] }} transition={{ duration: 26, repeat: Infinity, ease: "easeInOut" }} className="absolute bottom-[-10%] right-[-8%] h-[480px] w-[480px] rounded-full bg-primary/5 blur-[130px]" />
-        <div className="absolute inset-0 opacity-[0.025]" style={{ backgroundImage: `linear-gradient(to right, hsl(var(--foreground)) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--foreground)) 1px, transparent 1px)`, backgroundSize: "64px 64px" }} />
+        <div className="absolute inset-0 opacity-[0.025]" style={{ backgroundImage: "linear-gradient(to right, hsl(var(--foreground)) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--foreground)) 1px, transparent 1px)", backgroundSize: "64px 64px" }} />
       </div>
 
       <div className="relative z-10 flex min-h-dvh flex-col">
         <header className="flex items-center gap-3 border-b border-border/70 px-4 py-3 sm:px-6 lg:px-8">
           <BackButton />
-          <div className="min-w-0 flex-1"><div className="truncate text-sm font-medium">{space.name}</div><div className="text-xs text-muted-foreground">The story so far</div></div>
-          <Button variant="ghost" asChild className="rounded-full"><Link href={`/space/${space.slug}`}>Back to {space.name}</Link></Button>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium">{space.name}</div>
+            <div className="text-xs text-muted-foreground">The story so far</div>
+          </div>
+          <Button variant="ghost" asChild className="rounded-full">
+            <Link href={`/space/${space.slug}`}>Back to {space.name}</Link>
+          </Button>
         </header>
 
         <main className="flex min-h-0 flex-1 flex-col">
           <section className="mx-auto w-full max-w-7xl px-5 pb-8 pt-10 sm:px-8 sm:pt-16 lg:px-12">
-            <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
-              <div className="max-w-4xl"><div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground"><History className="h-3.5 w-3.5" />The story so far</div><h1 className="mt-4 text-5xl font-semibold tracking-tight sm:text-7xl lg:text-8xl">{space.name}</h1><p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">A visual record of the people, places and moments that shaped the {space.name} team.</p></div>
-              <div className="flex shrink-0 items-center gap-2"><Button variant="outline" size="icon" className="rounded-full" onClick={() => jump(-1)}><ArrowLeft className="h-4 w-4" /></Button><Button variant="outline" size="icon" className="rounded-full" onClick={() => jump(1)}><ArrowRight className="h-4 w-4" /></Button></div>
+            <div className="max-w-4xl">
+              <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                <History className="h-3.5 w-3.5" />
+                The story so far
+              </div>
+              <h1 className="mt-4 text-5xl font-semibold tracking-tight sm:text-7xl lg:text-8xl">{space.name}</h1>
+              <p className="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
+                A visual record of the people, places and moments that shaped the {space.name} team.
+              </p>
             </div>
 
             <div className="mt-8 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <div className="flex items-center gap-2 overflow-x-auto pb-1">{years.map((year) => <button key={year} type="button" onClick={() => jumpToYear(year)} className="shrink-0 rounded-full border border-border bg-background/70 px-4 py-2 text-xs font-medium text-muted-foreground transition hover:border-foreground/20 hover:text-foreground">{year}</button>)}</div>
-              <div className="flex items-center gap-2 overflow-x-auto pb-1 lg:justify-end">{["all", "member_joined", "report", "meeting", "event", "action", "announcement"].map((value) => <button key={value} type="button" onClick={() => setFilter(value)} className={`shrink-0 rounded-full px-4 py-2 text-xs font-medium transition ${filter === value ? "bg-foreground text-background" : "bg-muted text-muted-foreground hover:text-foreground"}`}>{value === "all" ? "Everything" : value === "member_joined" ? "People" : value === "announcement" ? "Updates" : value === "report" ? "Reports" : `${value.charAt(0).toUpperCase()}${value.slice(1)}s`}</button>)}</div>
-            </div>
+              <div className="flex items-center gap-2 overflow-x-auto pb-1">
+                {years.map((year) => (
+                  <span key={year} className="shrink-0 rounded-full border border-border bg-background/70 px-4 py-2 text-xs font-medium text-muted-foreground">
+                    {year}
+                  </span>
+                ))}
+              </div>
 
-            {monthMarkers.length ? <div className="mt-4 flex items-center gap-2 overflow-x-auto pb-1">{monthMarkers.map((month) => <button key={month.key} type="button" onClick={() => jumpToMonth(month.key)} className={`shrink-0 rounded-full border px-3 py-1.5 text-[11px] font-medium transition ${activeMonth === month.key ? "text-foreground shadow-sm" : "text-muted-foreground"}`} style={{ borderColor: activeMonth === month.key ? TIMELINE_COLORS[(month.year + month.index) % TIMELINE_COLORS.length].line : "hsl(var(--border))", background: "transparent" }}>{month.label}</button>)}</div> : null}
-          </section>
-
-          <section className="relative flex-1 pb-12">
-            <div ref={railRef} className="scrollbar-hide flex h-[64vh] min-h-[500px] items-stretch gap-0 overflow-x-auto overflow-y-hidden px-[7vw] py-6 sm:px-[8vw]">
-              <div className="relative flex min-w-max items-center py-24">
-                <div className="pointer-events-none absolute inset-x-0 top-1/2 z-[1] h-[3px] rounded-full bg-muted" />
-
-                {filteredEvents.map((event, eventIndex) => {
-                  const date = new Date(event.occurred_at);
-                  const monthKey = format(date, "yyyy-MM");
-                  const monthIndex = monthMarkers.findIndex((month) => month.key === monthKey);
-                  const color = TIMELINE_COLORS[(date.getFullYear() + Math.max(monthIndex, 0)) % TIMELINE_COLORS.length];
-                  const imageAttachments = safeArray(event.attachments).filter((item) => item?.mime_type?.startsWith("image/"));
-                  const governance = safeArray(event.governance_entities);
-                  const governanceCopy = governanceSentence(event, teamName);
-                  const above = eventIndex % 2 === 0;
-                  const isActive = activeMonth === monthKey;
-
-                  return (
-                    <div key={event.event_id} data-year={date.getFullYear()} data-month={monthKey} className="relative flex h-[560px] w-[410px] shrink-0 flex-col items-center justify-center">
-                      <motion.div className="pointer-events-none absolute left-1/2 z-[2] w-[2px] -translate-x-1/2" style={{ height: 140, top: above ? "calc(50% - 140px)" : "50%", background: color.line, opacity: isActive ? 1 : 0.28, boxShadow: isActive ? `0 0 10px ${color.soft}` : undefined }} animate={isActive ? { scaleY: [0.55, 1], opacity: [0.35, 1] } : { scaleY: 1, opacity: 0.28 }} transition={{ duration: 0.45, ease: "easeOut" }} />
-
-                      <motion.button
-                        type="button"
-                        onClick={() => setSelectedEvent(event)}
-                        className={`group relative z-10 h-[230px] w-[350px] overflow-hidden rounded-[30px] border bg-muted text-left shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary ${above ? "mb-[205px]" : "mt-[205px]"}`}
-                        style={{ borderColor: isActive ? color.line : "hsl(var(--border))", boxShadow: isActive ? `0 0 0 1px ${color.line}, 0 0 24px ${color.soft}` : undefined }}
-                        initial={{ opacity: 0, y: above ? 16 : -16 }}
-                        whileInView={{ opacity: 1, y: 0 }}
-                        viewport={{ once: true, amount: 0.2 }}
-                        transition={{ duration: 0.4, delay: Math.min(eventIndex * 0.025, 0.12) }}
-                      >
-                        {imageAttachments.length ? <AutoImageCarousel attachments={imageAttachments} /> : <div className="absolute inset-0 bg-gradient-to-br from-muted via-background to-muted-foreground/10" />}
-                        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent transition duration-300 group-hover:from-black/80" />
-                        <div className="absolute left-4 top-4 rounded-full bg-black/35 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.16em] text-white backdrop-blur">{format(date, "d MMM")}</div>
-                        {governance.length ? <div className="absolute right-4 top-4 flex -space-x-1.5">{governance.slice(0, 3).map((item) => item.image_url ? <img key={item.id} src={item.image_url} alt="" className="h-7 w-7 rounded-full border-2 border-black/30 bg-white/90 object-contain" /> : <div key={item.id} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black/20 bg-white/90 text-[9px] font-semibold text-foreground">{(item.short_name || item.label || "G").charAt(0)}</div>)}</div> : null}
-                        {event.event_type === "member_joined" ? <div className="absolute left-4 bottom-20 flex items-center gap-2 rounded-full bg-black/35 px-2 py-1.5 text-white backdrop-blur"><Avatar className="h-7 w-7 border border-white/20"><AvatarImage src={event.actor_avatar} alt={event.actor_name || ""} /><AvatarFallback>{event.actor_name?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback></Avatar><span className="max-w-[170px] truncate text-xs font-medium">{event.actor_name || "New member"}</span></div> : null}
-                        <div className="absolute inset-x-4 bottom-4 text-white"><div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/70">{pickVariant(event, NATURAL_TEXT[event.event_type] || NATURAL_TEXT.post)}</div><div className="mt-1 line-clamp-2 text-lg font-semibold leading-tight">{event.title}</div>{governanceCopy ? <div className="mt-1 line-clamp-1 text-xs text-white/60">{governanceCopy}</div> : null}</div>
-                      </motion.button>
-                    </div>
-                  );
-                })}
-
-                <div className="pointer-events-none absolute inset-x-0 top-1/2 z-[3] h-[3px] overflow-hidden rounded-full bg-muted">
-                  {activeMonthIndex >= 0 ? (
-                    <motion.div className="h-full rounded-full" initial={false} animate={{ width: `${Math.max(8, ((activeMonthIndex + 1) / Math.max(monthMarkers.length, 1)) * 100)}%` }} transition={{ duration: 0.55, ease: "easeOut" }} style={{ background: TIMELINE_COLORS[(monthMarkers[activeMonthIndex].year + activeMonthIndex) % TIMELINE_COLORS.length].line, boxShadow: `0 0 12px ${TIMELINE_COLORS[(monthMarkers[activeMonthIndex].year + activeMonthIndex) % TIMELINE_COLORS.length].soft}` }} />
-                  ) : null}
-                </div>
+              <div className="flex items-center gap-2 overflow-x-auto pb-1 lg:justify-end">
+                {["all", "member_joined", "report", "meeting", "event", "action", "announcement"].map((value) => (
+                  <button key={value} type="button" onClick={() => setFilter(value)} className={`shrink-0 rounded-full px-4 py-2 text-xs font-medium transition ${filter === value ? "bg-foreground text-background" : "bg-muted text-muted-foreground hover:text-foreground"}`}>
+                    {value === "all" ? "Everything" : value === "member_joined" ? "People" : value === "announcement" ? "Updates" : value === "report" ? "Reports" : `${value.charAt(0).toUpperCase()}${value.slice(1)}s`}
+                  </button>
+                ))}
               </div>
             </div>
           </section>
+
+          <AdaptiveTimelineRail
+            events={filteredEvents}
+            monthMarkers={monthMarkers}
+            activeMonth={activeMonth}
+            onMonthChange={setActiveMonth}
+            onSelectEvent={setSelectedEvent}
+          />
         </main>
       </div>
 
-      {selectedEvent ? <EventDialog event={selectedEvent} teamName={teamName} open={!!selectedEvent} onOpenChange={(open) => { if (!open) setSelectedEvent(null); }} /> : null}
+      {selectedEvent ? (
+        <EventDialog
+          event={selectedEvent}
+          teamName={teamName}
+          open={!!selectedEvent}
+          onOpenChange={(open) => {
+            if (!open) setSelectedEvent(null);
+          }}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Builds the Space timeline from the current main branch with adaptive orientation.

- Auto mode: horizontal on wide screens, vertical on narrower screens
- User preference toggle: Auto / Horizontal / Vertical
- Reuses shadcn Progress for the active rail
- Keeps existing PostLinks/LinkCard, AutoImageCarousel and Dialog
- Preserves natural-language/governance config and fallback image work from main
- Keeps timeline colors shared between month context and active rail/card styling

This branch is based on the latest main to avoid the earlier PR/deployment divergence.